### PR TITLE
MAKE-1022: Do not convert start/end to datetimes in performance results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.14 - 2019-11-14
+- Do not convert type of start/end in performance results.
+
 ## 0.6.13 - 2019-11-04
 - Add a windowing iterator.
 - Add a common import point.

--- a/src/evergreen/__init__.py
+++ b/src/evergreen/__init__.py
@@ -16,5 +16,5 @@ from evergreen.stats import TestStats, TaskStats
 from evergreen.task_reliability import TaskReliability
 from evergreen.version import Version
 
-VERSION = (0, 6, 13)
+VERSION = (0, 6, 14)
 __version__ = version_tuple_to_str(VERSION)

--- a/src/evergreen/build.py
+++ b/src/evergreen/build.py
@@ -94,3 +94,11 @@ class Build(_BaseEvergreenObject):
         if self.status != EVG_BUILD_STATUS_CREATED:
             return BuildMetrics(self).calculate(task_filter_fn)
         return None
+
+    def __repr__(self):
+        """
+        String representation of Task for debugging purposes.
+
+        :return: String representation of Task.
+        """
+        return "Build({id})".format(id=self.id)

--- a/src/evergreen/performance_results.py
+++ b/src/evergreen/performance_results.py
@@ -33,6 +33,7 @@ class PerformanceTestRun(_BaseEvergreenObject):
         """Get the start time for the given test run."""
         # Microbenchmarks stores the 'start' and 'end' time of the test in the inner 'results' field
         # while sys-perf stores it in the outer 'results' field.
+        # Also, the format of start varies depending on what generated the results.
         return self.json.get('start', self.json.get('results', {}).get('start'))
 
     @property
@@ -40,6 +41,7 @@ class PerformanceTestRun(_BaseEvergreenObject):
         """Get the start time for the given test run."""
         # Microbenchmarks stores the 'start' and 'end' time of the test in the inner 'results' field
         # while sys-perf stores it in the outer 'results' field.
+        # Also, the format of end varies depending on what generated the results.
         return self.json.get('end', self.json.get('results', {}).get('end'))
 
     @property

--- a/src/evergreen/performance_results.py
+++ b/src/evergreen/performance_results.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import
 
 from copy import copy
 
-from evergreen.base import _BaseEvergreenObject, evg_attrib, evg_short_datetime_attrib, \
-    evg_datetime_attrib
-from evergreen.util import parse_evergreen_datetime
+from evergreen.base import _BaseEvergreenObject, evg_attrib, evg_short_datetime_attrib
 
 
 class PerformanceTestResult(_BaseEvergreenObject):
@@ -30,23 +28,31 @@ class PerformanceTestRun(_BaseEvergreenObject):
         """Create an instance of a test run."""
         super(PerformanceTestRun, self).__init__(test_result, api)
 
+    @property
+    def start(self):
+        """Get the start time for the given test run."""
         # Microbenchmarks stores the 'start' and 'end' time of the test in the inner 'results' field
         # while sys-perf stores it in the outer 'results' field.
-        self.start = parse_evergreen_datetime(
-            test_result.get('start', test_result.get('results', {}).get('start')))
-        self.end = parse_evergreen_datetime(
-            test_result.get('end', test_result.get('results', {}).get('end')))
+        return self.json.get('start', self.json.get('results', {}).get('start'))
+
+    @property
+    def end(self):
+        """Get the start time for the given test run."""
+        # Microbenchmarks stores the 'start' and 'end' time of the test in the inner 'results' field
+        # while sys-perf stores it in the outer 'results' field.
+        return self.json.get('end', self.json.get('results', {}).get('end'))
 
     @property
     def test_results(self):
+        """Get the performance test results for this run."""
         return [PerformanceTestResult(item, self._api)
                 for item in _format_performance_results(self.json['results'])]
 
 
 class PerformanceTestBatch(_BaseEvergreenObject):
     """Representation of a batch of tests from Evergreen."""
-    start = evg_datetime_attrib('start')
-    end = evg_datetime_attrib('end')
+    start = evg_attrib('start')
+    end = evg_attrib('end')
     storage_engine = evg_attrib('storageEngine')
     errors = evg_attrib('errors')
 
@@ -84,6 +90,14 @@ class PerformanceData(_BaseEvergreenObject):
     @property
     def test_batch(self):
         return PerformanceTestBatch(self.json['data'], self._api, self)
+
+    def __repr__(self):
+        """
+        String representation of PerformanceData for debugging purposes.
+
+        :return: String representation of PreformanceData.
+        """
+        return "PerformanceData({id})".format(id=self.task_id)
 
 
 def _format_performance_results(results):
@@ -263,23 +277,6 @@ def _format_performance_results(results):
                 maxima[measurement] = max_copy
 
     return performance_results + list(maxima.values())
-
-
-def _get_test_metrics(results):
-    """
-    :param dict results: Performance test results in the format:
-    {
-        "average_read_latency_us":9312.337801629741,
-        "average_read_latency_us_values":[
-            9312.337801629741
-        ],
-        "ops_per_sec":13721.623145260504,
-        "ops_per_sec_values":[
-            13721.623145260504
-        ]
-    }
-    """
-    return
 
 
 def _is_run_matching(test_run, tests):

--- a/src/evergreen/task.py
+++ b/src/evergreen/task.py
@@ -224,3 +224,11 @@ class Task(_BaseEvergreenObject):
         :return: List of test results for the task.
         """
         return self._api.tests_by_task(self.task_id, status=status, execution=execution)
+
+    def __repr__(self):
+        """
+        String representation of Task for debugging purposes.
+
+        :return: String representation of Task.
+        """
+        return "Task({id})".format(id=self.task_id)

--- a/src/evergreen/version.py
+++ b/src/evergreen/version.py
@@ -136,3 +136,11 @@ class Version(_BaseEvergreenObject):
         if self.status != EVG_VERSION_STATUS_CREATED:
             return VersionMetrics(self).calculate(task_filter_fn)
         return None
+
+    def __repr__(self):
+        """
+        String representation of Version for debugging purposes.
+
+        :return: String representation of Version.
+        """
+        return "Version({id})".format(id=self.version_id)

--- a/tests/evergreen/test_performance_results.py
+++ b/tests/evergreen/test_performance_results.py
@@ -3,7 +3,7 @@ import random
 from copy import copy
 
 from evergreen.performance_results import PerformanceData
-from evergreen.util import parse_evergreen_datetime, parse_evergreen_short_datetime
+from evergreen.util import parse_evergreen_short_datetime
 
 from evergreen.performance_results import _format_performance_results
 
@@ -45,20 +45,16 @@ class TestPerformanceResults(object):
         test_batch = performance_data.test_batch
         test_batch_json = sample_performance_results['data']
 
-        assert test_batch.start == parse_evergreen_datetime(test_batch_json['start'])
-        assert test_batch.end == parse_evergreen_datetime(test_batch_json['end'])
+        assert test_batch.start == test_batch_json['start']
+        assert test_batch.end == test_batch_json['end']
         assert test_batch.errors == test_batch_json['errors']
         assert test_batch.storage_engine == test_batch_json['storageEngine']
 
         test_run = test_batch.test_runs[0]
         test_run_json = test_batch_json['results'][0]
 
-        assert test_run.start == parse_evergreen_datetime(
-            test_run_json['start'] if 'start' in test_run_json else test_run_json['results'][
-                'start'])
-        assert test_run.end == parse_evergreen_datetime(
-            test_run_json['end'] if 'end' in test_run_json else test_run_json['results'][
-                'end'])
+        assert test_run.start == test_run_json.get('start', test_run_json['results']['start'])
+        assert test_run.end == test_run_json.get('end', test_run_json['results']['end'])
         assert test_run.name == test_run_json['name']
         assert test_run.workload == test_run_json[
             'workload'] if 'workload' in test_run_json else 'microbenchmarks'


### PR DESCRIPTION
I'm keeping the 'start' and 'end' attributes, but not converting them to datetimes. That way if someone wants them, they can get them. 

Also, added `__repr__` functions to a bunch of objects to make logs nicer. 

And a bit of cleanup.