### PR TITLE
MAKE-1231: Rethrow exceptions after failed retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0 - 2020-04-07
+- Rethrow same exception if retries fail.
+
 ## 1.1.0 - 2020-02-18
 - Switch to poetry for dependency management.
 - Add mypy, black and pydocstyle checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "1.1.1"
+version = "1.2.0"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -951,6 +951,7 @@ class RetryingEvergreenApi(EvergreenApi):
         retry=retry_if_exception_type(requests.exceptions.HTTPError),
         stop=stop_after_attempt(MAX_RETRIES),
         wait=wait_exponential(multiplier=1, min=START_WAIT_TIME_SEC, max=MAX_WAIT_TIME_SEC),
+        reraise=True,
     )
     def _call_api(self, url: str, params: Dict = None) -> requests.Response:
         """

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from requests.exceptions import HTTPError
-from tenacity import RetryError
 
 import evergreen.api as under_test
 from evergreen.config import DEFAULT_API_SERVER, DEFAULT_NETWORK_TIMEOUT_SEC
@@ -416,7 +415,7 @@ class TestRetryingEvergreenApi(object):
         version_id = "version id"
         mocked_retrying_api.session.get.side_effect = HTTPError()
 
-        with pytest.raises(RetryError):
+        with pytest.raises(HTTPError):
             mocked_retrying_api.version_by_id(version_id)
 
         assert mocked_retrying_api.session.get.call_count == under_test.MAX_RETRIES


### PR DESCRIPTION
This is technically a breaking change, but I don't think we are relying on it anywhere. 