### PR TITLE
Fix response from /recent_versions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.2 - 2020-07-21
+- Fix wrapping of /projects/<id>/recent_versions API responses into an incompatible object
+
 ## 1.4.1 - 2020-07-05
 - Add API documentation site.
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,17 @@ $ evg-api --json list-hosts
 ...
 ```
 
+It may also be used from inside the repo using
+```
+$ poetry install
+$ poetry run python src/evergreen/cli/main.py
+```
 
 ## Contributors Guide
 
 ### Testing
 
-Use poetry and pytest for testing.    
+Use poetry and pytest for testing.
 ```
 $ poetry install
 $ poetry run pytest
@@ -81,9 +86,9 @@ $ RUN_SLOW_TEST=1 poetry run pytest
 Before deploying a new version, please update the `CHANGELOG.md` file with a description of what
 is being changed.
 
-Deploys to [PyPi](https://pypi.org/project/evergreen.py/) are done automatically on merges to master. 
+Deploys to [PyPi](https://pypi.org/project/evergreen.py/) are done automatically on merges to master.
 In order to avoid overwriting a previous deploy, the version should be updated on all changes. The
-[semver](https://semver.org/) versioning scheme should be used for determining the version number. 
+[semver](https://semver.org/) versioning scheme should be used for determining the version number.
 
 The version is found in the `pyproject.toml` file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "1.4.1"
+version = "1.4.2"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -273,7 +273,7 @@ class EvergreenApi(object):
         url = self._create_url("/projects/{project_id}".format(project_id=project_id))
         return Project(self._paginate(url), self)  # type: ignore[arg-type]
 
-    def recent_version_by_project(
+    def recent_versions_by_project(
         self, project_id: str, params: Optional[Dict] = None
     ) -> List[Version]:
         """
@@ -286,8 +286,9 @@ class EvergreenApi(object):
         url = self._create_url(
             "/projects/{project_id}/recent_versions".format(project_id=project_id)
         )
-        version_list = self._paginate(url, params)
-        return [Version(version, self) for version in version_list]  # type: ignore[arg-type]
+        version_list = self._call_api(url, params)
+
+        return version_list.json()  # type: ignore[arg-type]
 
     def versions_by_project(
         self, project_id: str, requester: Requester = Requester.GITTER_REQUEST

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -363,3 +363,6 @@ def build_stats(ctx, build_id, tasks):
 def main():
     """Create command line application."""
     return cli(obj={})
+
+if __name__ == '__main__':
+    main()

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -364,5 +364,6 @@ def main():
     """Create command line application."""
     return cli(obj={})
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/evergreen/config.py
+++ b/src/evergreen/config.py
@@ -43,9 +43,21 @@ def read_evergreen_config() -> Optional[Dict]:
 
 def get_auth_from_config(config: Dict) -> EvgAuth:
     """
-    Get the evergreen authentication from the specified config file.
+    Get the evergreen authentication from the specified config dict.
 
     :param config: Evergreen configuration.
     :return: Authentication information for evergreen.
     """
     return EvgAuth(config["user"], config["api_key"])
+
+
+def get_auth() -> EvgAuth:
+    """
+    Get the evergreen authentication object from the default locations. Convenience function.
+
+    :return: Authentication information for evergreen.
+    """
+    conf = read_evergreen_config()
+    if conf:
+        return get_auth_from_config(conf)
+    return None

--- a/src/evergreen/config.py
+++ b/src/evergreen/config.py
@@ -51,7 +51,7 @@ def get_auth_from_config(config: Dict) -> EvgAuth:
     return EvgAuth(config["user"], config["api_key"])
 
 
-def get_auth() -> EvgAuth:
+def get_auth() -> Optional[EvgAuth]:
     """
     Get the evergreen authentication object from the default locations. Convenience function.
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -151,7 +151,7 @@ class TestProjectApi(object):
         mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
 
     def test_recent_version_by_project(self, mocked_api):
-        mocked_api.recent_version_by_project("project_id")
+        mocked_api.recent_versions_by_project("project_id")
         expected_url = mocked_api._create_url("/projects/project_id/recent_versions")
         mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
 


### PR DESCRIPTION
The projects/id/recent_versions endpoint does not return json matching the schema expected by the Version class. 
For now, return the parsed json instead. 

Minor tweaks, and a utility function added for laptop-based use. 