### PR TITLE
DAG-517 Upgrade python requests to prevent ConnectionResetErrors when accessing Evergreen /projects endpoint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -856,8 +856,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "ed2947425f1a230e40ccf9a2198351a381e4cfe1976c76585be49d95ad786c38"
-lock-version = "1.0"
+content-hash = "f7bc5634b8df1588a87c23e527b366599143f0f2760f15460afb342021a644b4"
 python-versions = "^3.6.1"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ python = "^3.6.1"
 Click = "^7"
 python-dateutil = "^2"
 PyYAML = "^5"
-requests = "^2"
 structlog = "^19"
 tenacity = "^5"
+requests = "^2.24.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1"


### PR DESCRIPTION
I mentioned this issue in standup a few times, it used to be a TECHOPS ticket because I thought it was an issue with Kanopy, but @lviana found a fix for the issue in an updated version of the python requests library, so I am updating our python requests version.