### PR TITLE
Add endpoints for updating patches & tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1 - 2020-10-28
+- Add endpoints for updating patches and tasks
+
 ## 2.0.0 - 2020-10-28
 - Add py.typed file to allow clients to use type information.
 - Fix type issues in the API interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -420,8 +420,8 @@ class EvergreenApi(object):
 
         :param patch_id: Id of the patch to update
         :param variants: list of objects with keys "id" who's value is the variant ID, and key "tasks"
-        with value of a list of task names to configure for specified variant. See the documentation for more details
-        https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#configureschedule-a-patch
+            with value of a list of task names to configure for specified variant. See the documentation for more details
+            https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#configureschedule-a-patch
         :param description: If specified, will update the patch's description with the string provided
         """
         url = self._create_url(f"/patches/{patch_id}/configure")

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -412,7 +412,7 @@ class EvergreenApi(object):
     def configure_patch(
         self,
         patch_id: str,
-        variants: Optional[List[Dict[str, Union[str, List[str]]]]] = None,
+        variants: List[Dict[str, Union[str, List[str]]]],
         description: Optional[str] = None,
     ) -> None:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,7 @@ def mocked_api(mocked_api_response):
     """Return an Evergreen API with a mocked session."""
     api = EvergreenApi()
     api.session = MagicMock()
-    api.session.get.return_value = mocked_api_response
+    api.session.request.return_value = mocked_api_response
     return api
 
 
@@ -162,7 +162,7 @@ def mocked_cached_api():
     api.session = MagicMock()
     response_mock = MagicMock()
     response_mock.status_code = 200
-    api.session.get.return_value = response_mock
+    api.session.request.return_value = response_mock
     return api
 
 
@@ -173,7 +173,7 @@ def mocked_retrying_api():
     api.session = MagicMock()
     response_mock = MagicMock()
     response_mock.status_code = 200
-    api.session.get.return_value = response_mock
+    api.session.request.return_value = response_mock
     return api
 
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -246,14 +246,6 @@ class TestProjectApi(object):
             url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
         )
 
-    def test_configure_patch_description(self, mocked_api):
-        mocked_api.configure_patch("patch_id", description="mypatch")
-        expected_url = mocked_api._create_url("/patches/patch_id/configure")
-        expected_data = json.dumps({"description": "mypatch"})
-        mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
-        )
-
     def test_configure_patch_variants(self, mocked_api):
         variants = ["my_variant", ["task_one", "task_two"]]
         mocked_api.configure_patch("patch_id", variants=variants)

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from copy import deepcopy
@@ -54,7 +55,7 @@ class TestRaiseForStatus(object):
         mocked_response.json.side_effect = JSONDecodeError("json error", "", 0)
         mocked_response.status_code = 500
         mocked_response.raise_for_status.side_effect = HTTPError()
-        mocked_api.session.get.return_value = mocked_response
+        mocked_api.session.request.return_value = mocked_response
 
         with pytest.raises(HTTPError):
             mocked_api.version_by_id("version_id")
@@ -67,7 +68,7 @@ class TestRaiseForStatus(object):
         mocked_response.json.return_value = {"error": error_msg}
         mocked_response.status_code = 500
         mocked_response.raise_for_status.side_effect = HTTPError()
-        mocked_api.session.get.return_value = mocked_response
+        mocked_api.session.request.return_value = mocked_response
 
         with pytest.raises(HTTPError) as excinfo:
             mocked_api.version_by_id("version_id")
@@ -79,7 +80,7 @@ class TestRaiseForStatus(object):
 class TestLazyPagination(object):
     def test_with_no_next(self, mocked_api):
         returned_items = ["item 1", "item 2", "item 3"]
-        mocked_api.session.get.return_value.json.return_value = returned_items
+        mocked_api.session.request.return_value.json.return_value = returned_items
 
         results = mocked_api._lazy_paginate("http://url")
 
@@ -93,8 +94,8 @@ class TestLazyPagination(object):
     def test_next_in_response(self, mocked_api):
         returned_items = ["item 1", "item 2", "item 3"]
         next_url = "http://url_to_next"
-        mocked_api.session.get.return_value.json.return_value = returned_items
-        mocked_api.session.get.return_value.links = {"next": {"url": next_url}}
+        mocked_api.session.request.return_value.json.return_value = returned_items
+        mocked_api.session.request.return_value.links = {"next": {"url": next_url}}
 
         results = mocked_api._lazy_paginate("http://url")
 
@@ -110,22 +111,30 @@ class TestLazyPagination(object):
 class TestDistrosApi(object):
     def test_all_distros(self, mocked_api):
         mocked_api.all_distros()
-        mocked_api.session.get.assert_called_with(
-            url=mocked_api._create_url("/distros"), params=None, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=mocked_api._create_url("/distros"),
+            params=None,
+            timeout=None,
+            data=None,
+            method="GET",
         )
 
 
 class TestHostApi(object):
     def test_all_hosts(self, mocked_api):
         mocked_api.all_hosts()
-        mocked_api.session.get.assert_called_with(
-            url=mocked_api._create_url("/hosts"), params={}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=mocked_api._create_url("/hosts"), params={}, timeout=None, data=None, method="GET"
         )
 
     def test_all_hosts_with_status(self, mocked_api):
         mocked_api.all_hosts(status="success")
-        mocked_api.session.get.assert_called_with(
-            url=mocked_api._create_url("/hosts"), params={"status": "success"}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=mocked_api._create_url("/hosts"),
+            params={"status": "success"},
+            timeout=None,
+            data=None,
+            method="GET",
         )
 
 
@@ -133,7 +142,9 @@ class TestProjectApi(object):
     def test_all_projects(self, mocked_api):
         mocked_api.all_projects()
         expected_url = mocked_api._create_url("/projects")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_all_projects_with_filter(self, mocked_api, mocked_api_response, sample_projects):
         mocked_api_response.json.return_value = sample_projects
@@ -149,28 +160,32 @@ class TestProjectApi(object):
     def test_project_by_id(self, mocked_api):
         mocked_api.project_by_id("project_id")
         expected_url = mocked_api._create_url("/projects/project_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_recent_version_by_project(self, mocked_api):
         mocked_api.recent_versions_by_project("project_id")
         expected_url = mocked_api._create_url("/projects/project_id/recent_versions")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_version_by_project(self, mocked_api):
         returned_versions = mocked_api.versions_by_project("project_id")
         expected_url = mocked_api._create_url("/projects/project_id/versions")
         expected_params = {"requester": "gitter_request"}
         next(returned_versions)
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_alias_for_version(self, mocked_api):
         mocked_api.alias_for_version("version_id", "my_alias")
         expected_url = mocked_api._create_url("/projects/test_alias")
         expected_params = {"version": "version_id", "alias": "my_alias", "include_deps": False}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_versions_by_project_time_window(self, mocked_api, sample_version, mocked_api_response):
@@ -205,16 +220,43 @@ class TestProjectApi(object):
         patches = mocked_api.patches_by_project("project_id")
         next(patches)
         expected_url = mocked_api._create_url("/projects/project_id/patches")
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params={"limit": 100}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params={"limit": 100}, timeout=None, data=None, method="GET"
         )
 
     def test_patches_by_user(self, mocked_api):
         patches = mocked_api.patches_by_user("user_id")
         next(patches)
         expected_url = mocked_api._create_url("/users/user_id/patches")
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params={"limit": 100}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params={"limit": 100}, timeout=None, data=None, method="GET"
+        )
+
+    def test_configure_patch(self, mocked_api):
+        variants = ["my_variant", ["*"]]
+        description = "mypatch"
+        mocked_api.configure_patch("patch_id", description=description, variants=variants)
+        expected_url = mocked_api._create_url("/patches/patch_id/configure")
+        expected_data = json.dumps({"variants": variants, "description": description})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
+        )
+
+    def test_configure_patch_description(self, mocked_api):
+        mocked_api.configure_patch("patch_id", description="mypatch")
+        expected_url = mocked_api._create_url("/patches/patch_id/configure")
+        expected_data = json.dumps({"description": "mypatch"})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
+        )
+
+    def test_configure_patch_variants(self, mocked_api):
+        variants = ["my_variant", ["task_one", "task_two"]]
+        mocked_api.configure_patch("patch_id", variants=variants)
+        expected_url = mocked_api._create_url("/patches/patch_id/configure")
+        expected_data = json.dumps({"variants": variants})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
         )
 
     def test_patches_by_project_time_window(self, mocked_api, sample_patch, mocked_api_response):
@@ -248,7 +290,9 @@ class TestProjectApi(object):
     def test_commit_queue_for_project(self, mocked_api):
         mocked_api.commit_queue_for_project("project_id")
         expected_url = mocked_api._create_url("/commit_queue/project_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_test_stats_by_project(self, mocked_api):
         after_date = "2019-01-01"
@@ -259,20 +303,22 @@ class TestProjectApi(object):
             "after_date": after_date,
             "before_date": before_date,
         }
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_tasks_by_project(self, mocked_api):
         mocked_api.tasks_by_project("project_id")
         expected_url = mocked_api._create_url("/projects/project_id/versions/tasks")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_tasks_by_project_with_statuses(self, mocked_api):
         mocked_api.tasks_by_project("project_id", statuses=["status1"])
         expected_url = mocked_api._create_url("/projects/project_id/versions/tasks")
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params={"status": ["status1"]}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params={"status": ["status1"]}, timeout=None, data=None, method="GET"
         )
 
 
@@ -280,90 +326,104 @@ class TestBuildApi(object):
     def test_build_by_id(self, mocked_api):
         mocked_api.build_by_id("build_id")
         expected_url = mocked_api._create_url("/builds/build_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_tasks_by_build(self, mocked_api):
         mocked_api.tasks_by_build("build_id")
         expected_url = mocked_api._create_url("/builds/build_id/tasks")
-        mocked_api.session.get.assert_called_with(url=expected_url, params={}, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params={}, timeout=None, data=None, method="GET"
+        )
 
 
 class TestVersionApi(object):
     def test_version_by_id(self, mocked_api):
         mocked_api.version_by_id("version_id")
         expected_url = mocked_api._create_url("/versions/version_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_builds_by_version(self, mocked_api):
         mocked_api.builds_by_version("version_id")
         expected_url = mocked_api._create_url("/versions/version_id/builds")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
 
 class TestPatchApi(object):
     def test_patch_by_id(self, mocked_api):
         mocked_api.patch_by_id("patch_id")
         expected_url = mocked_api._create_url("/patches/patch_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
 
 class TestTaskApi(object):
     def test_task_by_id(self, mocked_api):
         mocked_api.task_by_id("task_id")
         expected_url = mocked_api._create_url("/tasks/task_id")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_task_by_id_with_fetch_executions(self, mocked_api):
         mocked_api.task_by_id("task_id", fetch_all_executions=True)
         expected_url = mocked_api._create_url("/tasks/task_id")
         expected_params = {"fetch_all_executions": True}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_manifest_for_task(self, mocked_api):
         mocked_api.manifest_for_task("task_id")
         expected_url = mocked_api._create_url("/tasks/task_id/manifest")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
     def test_tests_by_task(self, mocked_api):
         mocked_api.tests_by_task("task_id")
         expected_url = mocked_api._create_url("/tasks/task_id/tests")
         expected_params = {}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_tests_by_task_with_status(self, mocked_api):
         mocked_api.tests_by_task("task_id", status="success")
         expected_url = mocked_api._create_url("/tasks/task_id/tests")
         expected_params = {"status": "success"}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_tests_by_task_with_execution(self, mocked_api):
         mocked_api.tests_by_task("task_id", execution=5)
         expected_url = mocked_api._create_url("/tasks/task_id/tests")
         expected_params = {"execution": 5}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_tests_by_task_with_status_and_execution(self, mocked_api):
         mocked_api.tests_by_task("task_id", status="success", execution=5)
         expected_url = mocked_api._create_url("/tasks/task_id/tests")
         expected_params = {"status": "success", "execution": 5}
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_performance_results_by_task(self, mocked_api):
         mocked_api.performance_results_by_task("task_id")
         expected_url = mocked_api._create_plugin_url("/task/task_id/perf")
         expected_params = None
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_performance_results_by_task_name(self, mocked_api):
@@ -372,24 +432,84 @@ class TestTaskApi(object):
             api_server=DEFAULT_API_SERVER
         )
         expected_params = None
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_json_by_task(self, mocked_api):
         mocked_api.json_by_task("task_id", "json_key_id")
         expected_url = mocked_api._create_plugin_url("/task/task_id/json_key_id")
         expected_params = None
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
     def test_json_history_for_task(self, mocked_api):
         mocked_api.json_history_for_task("task_id", "task_name", "json_key_id")
         expected_url = f"{DEFAULT_API_SERVER}/api/2/task/task_id/json/history/task_name/json_key_id"
         expected_params = None
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
+        )
+
+    def test_restart_task(self, mocked_api):
+        mocked_api.restart_task("task_id")
+        expected_url = mocked_api._create_url("/tasks/task_id/restart")
+        expected_params = None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="POST"
+        )
+
+    def test_abort_task(self, mocked_api):
+        mocked_api.abort_task("task_id")
+        expected_url = mocked_api._create_url("/tasks/task_id/abort")
+        expected_params = None
+        expected_data = None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params=expected_params,
+            timeout=None,
+            data=expected_data,
+            method="POST",
+        )
+
+    def test_configure_task_activate(self, mocked_api):
+        mocked_api.configure_task("task_id", activated=True)
+        expected_url = mocked_api._create_url("/tasks/task_id")
+        expected_params = None
+        expected_data = json.dumps({"activated": True})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params=expected_params,
+            timeout=None,
+            data=expected_data,
+            method="PATCH",
+        )
+
+    def test_configure_task_priority(self, mocked_api):
+        mocked_api.configure_task("task_id", priority=100)
+        expected_url = mocked_api._create_url("/tasks/task_id")
+        expected_params = None
+        expected_data = json.dumps({"priority": 100})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params=expected_params,
+            timeout=None,
+            data=expected_data,
+            method="PATCH",
+        )
+
+    def test_configure_task(self, mocked_api):
+        mocked_api.configure_task("task_id", priority=100, activated=True)
+        expected_url = mocked_api._create_url("/tasks/task_id")
+        expected_params = None
+        expected_data = json.dumps({"activated": True, "priority": 100})
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params=expected_params,
+            timeout=None,
+            data=expected_data,
+            method="PATCH",
         )
 
 
@@ -397,18 +517,22 @@ class TestOldApi(object):
     def test_patch_by_id(self, mocked_api):
         mocked_api.manifest("project_id", "revision")
         expected_url = mocked_api._create_old_url("plugin/manifest/get/project_id/revision")
-        mocked_api.session.get.assert_called_with(url=expected_url, params=None, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
 
 
 class TestLogApi(object):
     def test_retrieve_log(self, mocked_api):
         mocked_api.retrieve_task_log("log_url")
-        mocked_api.session.get.assert_called_with(url="log_url", params={}, timeout=None)
+        mocked_api.session.request.assert_called_with(
+            url="log_url", params={}, timeout=None, data=None, method="GET"
+        )
 
     def test_retrieve_log_with_raw(self, mocked_api):
         mocked_api.retrieve_task_log("log_url", raw=True)
-        mocked_api.session.get.assert_called_with(
-            url="log_url", params={"text": "true"}, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url="log_url", params={"text": "true"}, timeout=None, data=None, method="GET"
         )
 
     def test_stream_log(self, mocked_api):
@@ -429,7 +553,7 @@ class TestCachedEvergreenApi(object):
         mocked_cached_api.build_by_id(build_id)
         mocked_cached_api.build_by_id(build_id)
         mocked_cached_api.build_by_id(another_build_id)
-        assert mocked_cached_api.session.get.call_count == 2
+        assert mocked_cached_api.session.request.call_count == 2
 
     def test_version_by_id_is_cached(self, mocked_cached_api):
         version_id = "some version id"
@@ -437,7 +561,7 @@ class TestCachedEvergreenApi(object):
         assert mocked_cached_api.version_by_id(version_id)
         assert mocked_cached_api.version_by_id(version_id)
         assert mocked_cached_api.version_by_id(another_version_id)
-        assert mocked_cached_api.session.get.call_count == 2
+        assert mocked_cached_api.session.request.call_count == 2
 
     def test_clear_caches(self, mocked_cached_api):
         build_id = "some build id"
@@ -447,7 +571,7 @@ class TestCachedEvergreenApi(object):
         mocked_cached_api.clear_caches()
         assert mocked_cached_api.build_by_id(build_id)
         assert mocked_cached_api.version_by_id(version_id)
-        assert mocked_cached_api.session.get.call_count == 4
+        assert mocked_cached_api.session.request.call_count == 4
 
 
 class TestRetryingEvergreenApi(object):
@@ -455,53 +579,53 @@ class TestRetryingEvergreenApi(object):
         version_id = "version id"
 
         mocked_retrying_api.version_by_id(version_id)
-        assert mocked_retrying_api.session.get.call_count == 1
+        assert mocked_retrying_api.session.request.call_count == 1
 
     @pytest.mark.skipif(
         not os.environ.get("RUN_SLOW_TESTS"), reason="Slow running test due to retries"
     )
     def test_three_retries_on_failure(self, mocked_retrying_api):
         version_id = "version id"
-        mocked_retrying_api.session.get.side_effect = HTTPError()
+        mocked_retrying_api.session.request.side_effect = HTTPError()
 
         with pytest.raises(HTTPError):
             mocked_retrying_api.version_by_id(version_id)
 
-        assert mocked_retrying_api.session.get.call_count == under_test.MAX_RETRIES
+        assert mocked_retrying_api.session.request.call_count == under_test.MAX_RETRIES
 
     @pytest.mark.skipif(
         not os.environ.get("RUN_SLOW_TESTS"), reason="Slow running test due to retries"
     )
     def test_pass_on_retries_after_failure(self, mocked_retrying_api):
         version_id = "version id"
-        successful_response = mocked_retrying_api.session.get.return_value
-        mocked_retrying_api.session.get.side_effect = [HTTPError(), successful_response]
+        successful_response = mocked_retrying_api.session.request.return_value
+        mocked_retrying_api.session.request.side_effect = [HTTPError(), successful_response]
 
         mocked_retrying_api.version_by_id(version_id)
 
-        assert mocked_retrying_api.session.get.call_count == 2
+        assert mocked_retrying_api.session.request.call_count == 2
 
     @pytest.mark.skipif(
         not os.environ.get("RUN_SLOW_TESTS"), reason="Slow running test due to retries"
     )
     def test_pass_on_retries_after_connection_error(self, mocked_retrying_api):
         version_id = "version id"
-        successful_response = mocked_retrying_api.session.get.return_value
+        successful_response = mocked_retrying_api.session.request.return_value
 
-        mocked_retrying_api.session.get.side_effect = [
+        mocked_retrying_api.session.request.side_effect = [
             requests.exceptions.ConnectionError(),
             successful_response,
         ]
 
         mocked_retrying_api.version_by_id(version_id)
 
-        assert mocked_retrying_api.session.get.call_count == 2
+        assert mocked_retrying_api.session.request.call_count == 2
 
     def test_no_retries_on_non_http_errors(self, mocked_retrying_api):
         version_id = "version id"
-        mocked_retrying_api.session.get.side_effect = ValueError("Unexpected Failure")
+        mocked_retrying_api.session.request.side_effect = ValueError("Unexpected Failure")
 
         with pytest.raises(ValueError):
             mocked_retrying_api.version_by_id(version_id)
 
-        assert mocked_retrying_api.session.get.call_count == 1
+        assert mocked_retrying_api.session.request.call_count == 1

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -349,8 +349,8 @@ class TestTaskStatsByProject(object):
             tasks=task_list,
         )
 
-        mocked_api.session.get.assert_called_with(
-            url=expected_url, params=expected_params, timeout=None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
 


### PR DESCRIPTION
### This pull requests adds coverage for the following endpoints to evergreen.py:
- POST [/tasks/{task_id}/restart](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#restart-a-task)
- POST [/tasks/{task_id}/abort](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#abort-a-task)
- PATCH [/tasks/{task_id}](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#change-a-tasks-execution-status)
- POST [/patches/{patch_id}/configure](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#configureschedule-a-patch)

### Refactoring included:
Refactored `_call_api` to be used for all requests -- instead of only GET. Another option would be to rename the method to reflect that it's only used for GET and add separate methods for POST & PATCH, however this would involve the same amount of line changes. 
