### PR TITLE
Add support for getting a test by task and test file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.5 - 2020-10-30
+- Add support for getting a single test by task id and test file
+
+## 2.0.4 - 2020-10-29
+- Allow structlog > 19
+
+## 2.0.3 - 2020-10-29
+- Add support for support for /projects/{project_id}/revisions/{commit_hash}/tasks
+
 ## 2.0.2 - 2020-10-28
 - Update recent versions endpoint to return a python class instead of raw JSON
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "2.0.2"
+version = "2.0.5"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -748,6 +748,17 @@ class EvergreenApi(object):
         url = self._create_url("/tasks/{task_id}/tests".format(task_id=task_id))
         return [Tst(test, self) for test in self._paginate(url, params)]  # type: ignore[arg-type]
 
+    def single_test_by_task_and_test_file(self, task_id: str, test_file: str) -> Tst:
+        """
+        Get a test for a given task.
+
+        :param task_id: Id of task to query for.
+        :param test_file: the name of the test_file of the test.
+        :return: the test for the specified task.
+        """
+        url = self._create_url(f"/tasks/{task_id}/tests")
+        return Tst(self._call_api(url, params={"test_name": test_file}).json(), self)
+
     def manifest_for_task(self, task_id: str) -> Manifest:
         """
         Get the manifest for the given task.

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -307,6 +307,17 @@ class TestProjectApi(object):
             url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
+    def test_single_test_by_task(self, mocked_api):
+        mocked_api.single_test_by_task_and_test_file("task_id", "com.xgen.module.MyTests.test1")
+        expected_url = mocked_api._create_url("/tasks/task_id/tests")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params={"test_name": "com.xgen.module.MyTests.test1"},
+            timeout=None,
+            data=None,
+            method="GET",
+        )
+
     def test_tasks_by_project(self, mocked_api):
         mocked_api.tasks_by_project("project_id")
         expected_url = mocked_api._create_url("/projects/project_id/versions/tasks")


### PR DESCRIPTION
https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#id58

Add support for getting a single test by it's test file name and associated task_id 