### PR TITLE
upgrade tenacity version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 3.0.5 - 2021-04-07
+- Allow tenacity > 5
+
 ## 3.0.4 - 2021-04-06
 - Added helper functions to the `Task` and `Build` objects to fetch the project `identifier` field.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.0.4"
+version = "3.0.5"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",
@@ -28,7 +28,7 @@ python-dateutil = "^2"
 PyYAML = "^5"
 requests = "^2"
 structlog = ">=19"
-tenacity = "^5"
+tenacity = ">=5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1"


### PR DESCRIPTION
While using latest evergreen.py with python 3.9.0, I'm getting following warnings:

```
=============================== warnings summary ===============================
../../usr/local/lib/python3.9/site-packages/tenacity/_asyncio.py:42
  /usr/local/lib/python3.9/site-packages/tenacity/_asyncio.py:42: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def call(self, fn, *args, **kwargs):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

This issue is already fixed in tenacity 6.1.0 https://github.com/jd/tenacity/commit/66de0110844a742b820ab6c1f29edb19ed2e5908

I have updated pyproject.toml to allow `tenacity >= 5` so that I can get rid of above mentioned warning with python 3.9.0