### PR TITLE
Add CLI support for manifests and module hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.8 - 2021-05-04
+- Added command to get a manifest.
+
 ## 3.0.7 - 2021-04-30
 - Fix incorrect mapping for TaskStats `num_pass`, `num_fail` and `avg_duration_pass` fields.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.0.7"
+version = "3.0.8"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -371,6 +371,26 @@ def build_stats(ctx, build_id, tasks):
         click.echo(fmt_output(fmt, build.get_metrics().as_dict(include_children=tasks)))
 
 
+@cli.command()
+@click.pass_context
+@click.option("--project", required=True, help="The project name")
+@click.option("--commit", required=True, help="The full 40-char commit hash")
+def manifest(ctx, project, commit):
+    """
+    Get a manifest for the given project and commit.
+
+    Example: use jq to get a module version associated with a main-repo version:
+
+    evg-api --json manifest --project <PROJECT> --commit <MAIN-REPO-HASH> \\
+        | jq --raw-output .modules.<MODULE-NAME>.revision
+    """
+    api = ctx.obj["api"]
+    fmt = ctx.obj["format"]
+
+    manifest = api.manifest(project, commit)
+    click.echo(fmt_output(fmt, manifest.json))
+
+
 def main():
     """Create command line application."""
     return cli(obj={})


### PR DESCRIPTION
Adds two evg-api commands:

"manifest" gets the manifest for a project and commit hash.

"get-module-commit" gets a module commit from a project and commit hash. E.g., get the "wtdevelop" commit for the "mongo" project like this:
```
> evg-api get-module-commit --project mongodb-mongo-master --commit 51bef6c2d9d035afed3735ea107d1e7b58392d93 --module wtdevelop
cf79d062ecdaa7509ca80c4a643268ee5303e915
```
This may be useful for developers in a git checkout hook to keep modules in sync with their main repo.