### PR TITLE
DAG-1210: Add tests for the evergreen.py command line app

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -143,7 +143,7 @@ tasks:
         . evg-api-cli-venv/bin/activate
 
         pip install --upgrade pip
-        pip install evg-api
+        pip install git+ssh://git@github.com/evergreen-ci/evergreen.py.git
 
         evg-api --help
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -140,11 +140,8 @@ tasks:
         /opt/mongodbtoolchain/v3/bin/python3 -m venv evg-api-cli-venv
         . evg-api-cli-venv/bin/activate
 
-        ls
-        ls ..
-        
         pip install --upgrade pip
-        pip install ..
+        pip install .
 
         evg-api --help
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -124,6 +124,23 @@ tasks:
 
         COVERALLS_REPO_TOKEN=${coveralls_repo_token|} poetry run coveralls
 
+- name: evg_api_install
+  commands:
+  - command: shell.exec
+    params:
+      working_dir: src
+      script: |
+        set -o errexit
+        set -o verbose
+
+        export LC_ALL=C.UTF-8
+        export LANG=C.UTF-8
+
+        . venv/bin/activate
+
+        poetry install
+        poetry run evg-api --help
+
 - name: deploy
   patchable: false
   depends_on:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -7,6 +7,7 @@ buildvariants:
   - name: unit_tests
   - name: deploy
   - name: documentation
+  - name: evg_api_install
 
 functions:
   create virtualenv:
@@ -136,10 +137,8 @@ tasks:
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
 
-        . venv/bin/activate
-
-        poetry install
-        poetry run evg-api --help
+        pip install evergreen.py
+        evg-api --help
 
 - name: deploy
   patchable: false

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -137,13 +137,11 @@ tasks:
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
 
-        mkdir evg-api-cli
-        cd evg-api-cli
         /opt/mongodbtoolchain/v3/bin/python3 -m venv evg-api-cli-venv
         . evg-api-cli-venv/bin/activate
 
         pip install --upgrade pip
-        pip install git+ssh://git@github.com/evergreen-ci/evergreen.py.git
+        pip install .
 
         evg-api --help
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -141,7 +141,7 @@ tasks:
         . evg-api-cli-venv/bin/activate
 
         pip install --upgrade pip
-        pip install .
+        pip install ..
 
         evg-api --help
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -137,6 +137,12 @@ tasks:
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
 
+        /opt/mongodbtoolchain/v3/bin/python3 -m venv evg-api-cli-venv
+        . evg-api-cli-venv/bin/activate
+
+        ls
+        ls ..
+        
         pip install --upgrade pip
         pip install ..
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -137,7 +137,14 @@ tasks:
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
 
-        pip install evergreen.py
+        mkdir evg-api-cli
+        cd evg-api-cli
+        /opt/mongodbtoolchain/v3/bin/python3 -m venv evg-api-cli-venv
+        . evg-api-cli-venv/bin/activate
+
+        pip install --upgrade pip
+        pip install evg-api
+
         evg-api --help
 
 - name: deploy

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -137,9 +137,6 @@ tasks:
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
 
-        /opt/mongodbtoolchain/v3/bin/python3 -m venv evg-api-cli-venv
-        . evg-api-cli-venv/bin/activate
-
         pip install --upgrade pip
         pip install ..
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1 - 2021-06-21
+- Added testing for `evg-api` command.
+
 ## 3.1.0 - 2021-06-02
 - Update readme.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -71,9 +71,9 @@ def list_patches(ctx, project, limit):
     fmt = ctx.obj["format"]
     patches = []
     for i, p in enumerate(api.patches_by_project(project)):
-        patches.append(p.json)
-        if limit and i > limit:
+        if limit and i >= limit:
             break
+        patches.append(p.json)
     click.echo(fmt_output(fmt, patches))
 
 
@@ -98,7 +98,7 @@ def list_versions(ctx, project: str, start: Optional[int], limit: Optional[int])
     api = ctx.obj["api"]
     fmt = ctx.obj["format"]
     version_list = api.versions_by_project(project, start=start, limit=limit)
-    versions_to_display = [version for version in islice(version_list, None, limit)]
+    versions_to_display = [version.json for version in islice(version_list, None, limit)]
 
     click.echo(fmt_output(fmt, versions_to_display))
 

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -1,3 +1,7 @@
+import json
+
+from evergreen import Manifest, TaskStats, TestStats, Version
+
 try:
     from unittest.mock import MagicMock
 except ImportError:
@@ -51,6 +55,8 @@ def test_list_patches(monkeypatch, sample_patch, output_fmt):
         cmd_list = [output_fmt] + cmd_list
     result = runner.invoke(under_test.cli, cmd_list)
     assert result.exit_code == 0
+    if output_fmt == "--json":
+        assert len(json.loads(result.output)) == 5
     assert sample_patch["patch_id"] in result.output
 
 
@@ -65,3 +71,159 @@ def test_list_projects(monkeypatch, sample_project, output_fmt):
     result = runner.invoke(under_test.cli, cmd_list)
     assert result.exit_code == 0
     assert sample_project["identifier"] in result.output
+
+
+def test_list_versions(monkeypatch, sample_version, output_fmt):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    evg_api_mock.versions_by_project.return_value = [
+        Version(sample_version, None) for _ in range(10)
+    ]
+
+    runner = CliRunner()
+    cmd_list = ["list-versions", "--project", "project", "--limit", "5"]
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    if output_fmt == "--json":
+        assert len(json.loads(result.output)) == 5
+    assert sample_version["version_id"] in result.output
+
+
+def test_send_slack_message(monkeypatch):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_send_slack_message = MagicMock()
+    evg_api_mock.send_slack_message = mock_send_slack_message
+
+    runner = CliRunner()
+    cmd_list = ["send-slack-message", "--target", "test_target", "--msg", "test_msg"]
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert mock_send_slack_message.call_count == 1
+    assert mock_send_slack_message.call_args[0] == ("test_target", "test_msg")
+
+
+def test_test_stats(monkeypatch, sample_test_stats, output_fmt):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_test_stats = MagicMock()
+    evg_api_mock.test_stats_by_project = mock_test_stats
+    evg_api_mock.test_stats_by_project.return_value = [
+        TestStats(sample_test_stats, None) for _ in range(10)
+    ]
+
+    cmd_list = ["test-stats", "-a", "after-date", "-b", "before-date", "-p", "project"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert sample_test_stats["test_file"] in result.output
+    assert "after-date" in mock_test_stats.call_args[0]
+    assert "before-date" in mock_test_stats.call_args[0]
+    assert "project" in mock_test_stats.call_args[0]
+
+
+def test_task_stats(monkeypatch, sample_task_stats, output_fmt):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_task_stats = MagicMock()
+    evg_api_mock.task_stats_by_project = mock_task_stats
+    evg_api_mock.task_stats_by_project.return_value = [
+        TaskStats(sample_task_stats, None) for _ in range(10)
+    ]
+
+    cmd_list = ["task-stats", "-a", "after-date", "-b", "before-date", "-p", "project"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert sample_task_stats["task_name"] in result.output
+    assert "after-date" in mock_task_stats.call_args[0]
+    assert "before-date" in mock_task_stats.call_args[0]
+    assert "project" in mock_task_stats.call_args[0]
+
+
+def test_task_reliability(monkeypatch, sample_task_reliability, output_fmt):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_task_reliability = MagicMock()
+    evg_api_mock.task_reliability_by_project = mock_task_reliability
+    evg_api_mock.task_reliability_by_project.return_value = [
+        TaskStats(sample_task_reliability, None) for _ in range(10)
+    ]
+
+    cmd_list = ["task-reliability", "-p", "project", "-t", "task1", "-t", "task2"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert sample_task_reliability["task_name"] in result.output
+    assert "project" in mock_task_reliability.call_args[0]
+    assert ("task1", "task2") in mock_task_reliability.call_args[0]
+
+
+def test_version_stats(monkeypatch, output_fmt):
+    mock_version_metrics = MagicMock()
+    mock_version_metrics.as_dict.return_value = "get_metrics_as_dict"
+
+    mock_version = MagicMock(version_id="version_id")
+    mock_version.get_metrics.return_value = mock_version_metrics if output_fmt else "get_metrics"
+
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_version_by_id = MagicMock()
+    evg_api_mock.version_by_id = mock_version_by_id
+    evg_api_mock.version_by_id.return_value = mock_version
+
+    cmd_list = ["version-stats", "-v", "version_id"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert "get_metrics_as_dict" in result.output if output_fmt else "get_metrics"
+    assert "version_id" in mock_version_by_id.call_args[0]
+
+
+def test_build_stats(monkeypatch, output_fmt):
+    mock_build_metrics = MagicMock()
+    mock_build_metrics.as_dict.return_value = "get_metrics_as_dict"
+
+    mock_build = MagicMock(build_id="build_id")
+    mock_build.get_metrics.return_value = mock_build_metrics if output_fmt else "get_metrics"
+
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_build_by_id = MagicMock()
+    evg_api_mock.build_by_id = mock_build_by_id
+    evg_api_mock.build_by_id.return_value = mock_build
+
+    cmd_list = ["build-stats", "-b", "build_id"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert "get_metrics_as_dict" in result.output if output_fmt else "get_metrics"
+    assert "build_id" in mock_build_by_id.call_args[0]
+
+
+def test_manifest(monkeypatch, sample_manifest, output_fmt):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    mock_manifest = MagicMock()
+    evg_api_mock.manifest = mock_manifest
+    evg_api_mock.manifest.return_value = Manifest(sample_manifest, None)
+
+    cmd_list = ["manifest", "--project", "project", "--commit", "commit"]
+
+    runner = CliRunner()
+    if output_fmt:
+        cmd_list = [output_fmt] + cmd_list
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0
+    assert sample_manifest["id"] in result.output
+    assert "project" in mock_manifest.call_args[0]
+    assert "commit" in mock_manifest.call_args[0]


### PR DESCRIPTION
Added testing to the `evg-api` commands. Currently, the `main.py` file has 98% coverage.
I also, added a new task to test proper installation of `evg-api`.

![Screen Shot 2021-06-21 at 5 23 13 PM](https://user-images.githubusercontent.com/62212154/122844020-9e332e80-d2b5-11eb-8fbf-4ef38356c65f.png)