### PR TITLE
Add support for  `give roles to user` API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.0 - 2021-09-17
+- Added support for `give roles to user` API endpoint.
+
 ## 3.2.9 - 2021-09-10
 - Removed admin permission requirement for `project_identifier` access.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.2.9"
+version = "3.3.0"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1036,6 +1036,22 @@ class EvergreenApi(object):
         }
         self._call_api(url, method="POST", data=json.dumps(payload))
 
+    def give_roles_to_user(self, user_id: str, roles: List[str], create_user: bool = False) -> None:
+        """
+        Add the specified role to the specified user.
+
+        :param user_id: Id of the user to give the roles to.
+        :param roles: A list of roles to give to the user.
+        :param create_user: If true, will also create a user document for the user.
+        """
+        url = self._create_url(f"/users/{user_id}/roles")
+        payload = {
+            "user_id": user_id,
+            "roles": roles,
+            "create_user": create_user,
+        }
+        self._call_api(url, method="POST", data=json.dumps(payload))
+
     def delete_user_permissions(self, user_id: str, resource_type: RemovablePermission) -> None:
         """
         Delete all permissions of a given type for a user.

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -428,15 +428,15 @@ def delete_user_permissions(ctx, user_id, resource_type):
 
 @cli.command()
 @click.pass_context
-@click.option("--user-id", required=True, help="User to give the role to.")
+@click.option("--user-id", required=True, help="User to grant roles to.")
 @click.option(
-    "--role", required=True, help="Role to grant the user.",
+    "--role", required=True, multiple=True, help="Role to grant the user.",
 )
 def give_role_to_user(ctx, user_id, role):
-    """Grant a role to a user."""
+    """Grant roles to a user."""
     api = ctx.obj["api"]
-    api.give_roles_to_user(user_id, [role])
-    click.echo(f"Successfully granted role {role} to user {user_id}")
+    api.give_roles_to_user(user_id, list(role))
+    click.echo(f"Successfully granted roles {role} to user {user_id}")
 
 
 def main():

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -426,6 +426,19 @@ def delete_user_permissions(ctx, user_id, resource_type):
     click.echo(f"Sucessfully deleted {resource_type} permissions for user {user_id}")
 
 
+@cli.command()
+@click.pass_context
+@click.option("--user-id", required=True, help="User to give the role to.")
+@click.option(
+    "--role", required=True, help="Role to grant the user.",
+)
+def give_role_to_user(ctx, user_id, role):
+    """Grant a role to a user."""
+    api = ctx.obj["api"]
+    api.give_roles_to_user(user_id, [role])
+    click.echo(f"Successfully granted role {role} to user {user_id}")
+
+
 def main():
     """Create command line application."""
     return cli(obj={})

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -432,7 +432,7 @@ def delete_user_permissions(ctx, user_id, resource_type):
 @click.option(
     "--role", required=True, multiple=True, help="Role to grant the user.",
 )
-def give_role_to_user(ctx, user_id, role):
+def give_roles_to_user(ctx, user_id, role):
     """Grant roles to a user."""
     api = ctx.obj["api"]
     api.give_roles_to_user(user_id, list(role))

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -271,7 +271,15 @@ def test_give_role_to_user(monkeypatch):
     evg_api_mock = _create_api_mock(monkeypatch)
     evg_api_mock.give_roles_to_user.return_value = {}
 
-    cmd_list = ["give-role-to-user", "--user-id", "test.user", "--role", "role1", "--role", "role2"]
+    cmd_list = [
+        "give-roles-to-user",
+        "--user-id",
+        "test.user",
+        "--role",
+        "role1",
+        "--role",
+        "role2",
+    ]
 
     runner = CliRunner()
     result = runner.invoke(under_test.cli, cmd_list)

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -265,3 +265,14 @@ def test_delete_user_permissions(monkeypatch, output_fmt):
         cmd_list = [output_fmt] + cmd_list
     result = runner.invoke(under_test.cli, cmd_list)
     assert result.exit_code == 0
+
+
+def test_give_role_to_user(monkeypatch):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    evg_api_mock.give_roles_to_user.return_value = {}
+
+    cmd_list = ["give-role-to-user", "--user-id", "test.user", "--role", "role1"]
+
+    runner = CliRunner()
+    result = runner.invoke(under_test.cli, cmd_list)
+    assert result.exit_code == 0

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -271,8 +271,9 @@ def test_give_role_to_user(monkeypatch):
     evg_api_mock = _create_api_mock(monkeypatch)
     evg_api_mock.give_roles_to_user.return_value = {}
 
-    cmd_list = ["give-role-to-user", "--user-id", "test.user", "--role", "role1"]
+    cmd_list = ["give-role-to-user", "--user-id", "test.user", "--role", "role1", "--role", "role2"]
 
     runner = CliRunner()
     result = runner.invoke(under_test.cli, cmd_list)
+    evg_api_mock.give_roles_to_user.assert_called_once_with("test.user", ["role1", "role2"])
     assert result.exit_code == 0

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -762,6 +762,20 @@ class TestUserPermissionsApi(object):
         )
 
 
+class TestRolesApi(object):
+    @pytest.mark.parametrize("create_user", [False, True])
+    def test_give_roles_to_user(self, mocked_api, create_user):
+        expected_url = mocked_api._create_url("/users/test.user/roles")
+        roles = ["role1", "role2"]
+        expected_data = json.dumps(
+            {"user_id": "test.user", "roles": roles, "create_user": create_user}
+        )
+        mocked_api.give_roles_to_user("test.user", roles, create_user)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
+        )
+
+
 class TestCachedEvergreenApi(object):
     def test_build_by_id_is_cached(self, mocked_cached_api):
         build_id = "some build id"


### PR DESCRIPTION
* Adds support for the `give roles to user` API endpoint.
* Add a CLI command that will allow a user to do the same but we limit the interaction to grant one role at a time to keep it simple.