### PR TITLE
Add resource_id param to delete user permissions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.1 - 2021-09-24
+- Delete user permissions endpoint now supports a resource_id param.
+
 ## 3.3.0 - 2021-09-17
 - Added support for `give roles to user` API endpoint.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.3.0"
+version = "3.3.1"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1052,15 +1052,21 @@ class EvergreenApi(object):
         }
         self._call_api(url, method="POST", data=json.dumps(payload))
 
-    def delete_user_permissions(self, user_id: str, resource_type: RemovablePermission) -> None:
+    def delete_user_permissions(
+        self, user_id: str, resource_type: RemovablePermission, resource_id: Optional[str] = None
+    ) -> None:
         """
         Delete all permissions of a given type for a user.
 
         :param user_id: Id of the user whose permissions to remove.
         :param resource_type: A permission that can be removed.
+        :param resource_id: Resource id for which to delete permissions. Required unless
+                            deleting all permissions.
         """
         url = self._create_url(f"/users/{user_id}/permissions")
-        payload = {"resource_type": resource_type}
+        payload = {"resource_type": resource_type.value}
+        if resource_id:
+            payload["resource_id"] = resource_id
         self._call_api(url, method="DELETE", data=json.dumps(payload))
 
     @classmethod

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -10,6 +10,7 @@ import click
 import yaml
 
 from evergreen import EvergreenApi
+from evergreen.resource_type_permissions import RemovablePermission
 
 DisplayFormat = Enum("DisplayFormat", "human json yaml")
 
@@ -419,11 +420,21 @@ def user_permissions(ctx, user_id):
     type=click.Choice(["project", "distro", "superuser", "all"], case_sensitive=False),
     help="Type of resource for which to delete permissions.",
 )
-def delete_user_permissions(ctx, user_id, resource_type):
+@click.option(
+    "--resource-id",
+    required=False,
+    help="Id of the resource for which to delete permissions. Required unless deleting all permissions.",
+)
+def delete_user_permissions(ctx, user_id, resource_type, resource_id):
     """Delete all permissions of a given type for a user."""
     api = ctx.obj["api"]
-    api.delete_user_permissions(user_id, resource_type)
-    click.echo(f"Sucessfully deleted {resource_type} permissions for user {user_id}")
+    api.delete_user_permissions(user_id, RemovablePermission(resource_type), resource_id)
+    if resource_id:
+        click.echo(
+            f"Sucessfully deleted {resource_type} permissions for user {user_id} on resource id {resource_id}"
+        )
+    else:
+        click.echo(f"Sucessfully deleted {resource_type} permissions for user {user_id}")
 
 
 @cli.command()

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -272,7 +272,7 @@ def test_user_permissions(cmd_list, monkeypatch, sample_permissions, output_fmt)
         ],
     ],
 )
-def test_delete_user_permissions_all(monkeypatch, output_fmt, cmd_list, resource_id):
+def test_delete_user_permissions(monkeypatch, output_fmt, cmd_list, resource_id):
     evg_api_mock = _create_api_mock(monkeypatch)
     evg_api_mock.delete_user_permissions.return_value = {}
 

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -1,7 +1,7 @@
 import json
 
 from evergreen import Manifest, TaskStats, TestStats, Version
-from evergreen.resource_type_permissions import ResourceTypePermissions
+from evergreen.resource_type_permissions import RemovablePermission, ResourceTypePermissions
 
 try:
     from unittest.mock import MagicMock
@@ -254,16 +254,35 @@ def test_user_permissions(cmd_list, monkeypatch, sample_permissions, output_fmt)
     assert "permissions" in sample_permissions[0]
 
 
-def test_delete_user_permissions(monkeypatch, output_fmt):
+@pytest.mark.parametrize(
+    "cmd_list,resource_id",
+    [
+        [["delete-user-permissions", "--user-id", "test.user", "--resource-type", "project"], None],
+        [
+            [
+                "delete-user-permissions",
+                "--user-id",
+                "test.user",
+                "--resource-type",
+                "project",
+                "--resource-id",
+                "testresource",
+            ],
+            "testresource",
+        ],
+    ],
+)
+def test_delete_user_permissions_all(monkeypatch, output_fmt, cmd_list, resource_id):
     evg_api_mock = _create_api_mock(monkeypatch)
     evg_api_mock.delete_user_permissions.return_value = {}
-
-    cmd_list = ["delete-user-permissions", "--user-id", "test.user", "--resource-type", "project"]
 
     runner = CliRunner()
     if output_fmt:
         cmd_list = [output_fmt] + cmd_list
     result = runner.invoke(under_test.cli, cmd_list)
+    evg_api_mock.delete_user_permissions.assert_called_once_with(
+        "test.user", RemovablePermission.PROJECT, resource_id
+    )
     assert result.exit_code == 0
 
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -753,10 +753,20 @@ class TestUserPermissionsApi(object):
             url=expected_url, params=None, timeout=None, data=expected_data, method="POST",
         )
 
-    def test_delete_user_permissions(self, mocked_api):
+    def test_delete_user_permissions_all_resources(self, mocked_api):
         expected_url = mocked_api._create_url("/users/test.user/permissions")
         expected_data = json.dumps({"resource_type": RemovablePermission.PROJECT.value})
         mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT)
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
+        )
+
+    def test_delete_user_permissions_specific_resource(self, mocked_api):
+        expected_url = mocked_api._create_url("/users/test.user/permissions")
+        expected_data = json.dumps(
+            {"resource_type": RemovablePermission.PROJECT.value, "resource_id": "testresource"}
+        )
+        mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT, "testresource")
         mocked_api.session.request.assert_called_with(
             url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
         )


### PR DESCRIPTION
* Add resource_id param to delete user permissions endpoint. 
** This was just added earlier today to evergreen core.