### PR TITLE
Add get users for role endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.2 - 2021-09-24
+- Add 'get users for role' endpoint.
+
 ## 3.3.1 - 2021-09-24
 - Delete user permissions endpoint now supports a resource_id param.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.3.1"
+version = "3.3.2"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1063,6 +1063,15 @@ class EvergreenApi(object):
         payload = {"resource_type": resource_type}
         self._call_api(url, method="DELETE", data=json.dumps(payload))
 
+    def get_users_for_role(self, role: str) -> List[str]:
+        """
+        Get a list of users having an evergreen role.
+
+        :param role: Role to fetch users for.
+        """
+        url = self._create_url(f"/roles/{role}/users")
+        return self._call_api(url, method="GET").json()
+
     @classmethod
     def get_api(
         cls,

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -439,6 +439,18 @@ def give_roles_to_user(ctx, user_id, role):
     click.echo(f"Successfully granted roles {role} to user {user_id}")
 
 
+@cli.command()
+@click.pass_context
+@click.option(
+    "--role", required=True, help="Role to fetch users for.",
+)
+def get_users_for_role(ctx, role):
+    """Get users having an evergreen role."""
+    api = ctx.obj["api"]
+    users = api.get_users_for_role(role)
+    click.echo(users)
+
+
 def main():
     """Create command line application."""
     return cli(obj={})

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -285,3 +285,17 @@ def test_give_role_to_user(monkeypatch):
     result = runner.invoke(under_test.cli, cmd_list)
     evg_api_mock.give_roles_to_user.assert_called_once_with("test.user", ["role1", "role2"])
     assert result.exit_code == 0
+
+
+def test_get_users_for_role(monkeypatch):
+    evg_api_mock = _create_api_mock(monkeypatch)
+    users = ["user1", "user2"]
+    evg_api_mock.get_users_for_role.return_value = {"users": users}
+
+    cmd_list = ["get-users-for-role", "--role", "testrole"]
+
+    runner = CliRunner()
+    result = runner.invoke(under_test.cli, cmd_list)
+    evg_api_mock.get_users_for_role.assert_called_once_with("testrole")
+    assert result.exit_code == 0
+    assert "user1" in result.output

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -775,6 +775,16 @@ class TestRolesApi(object):
             url=expected_url, params=None, timeout=None, data=expected_data, method="POST"
         )
 
+    def test_get_users_for_role(self, mocked_api, mocked_api_response):
+        expected_url = mocked_api._create_url("/roles/testrole/users")
+        users = ["test1", "test2", "test3"]
+        mocked_api_response.json.return_value = {"users": users}
+        returned_response = mocked_api.get_users_for_role("testrole")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
+        assert returned_response == {"users": users}
+
 
 class TestCachedEvergreenApi(object):
     def test_build_by_id_is_cached(self, mocked_cached_api):


### PR DESCRIPTION
* Adds support for the `get users for role` endpoint - https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-users-for-role