### PR TITLE
Fix inconsistency in get users for role endpoint's return type hint a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.3 - 2021-09-25
+- Fixes inconsistency in `get users for role` endpoint's return type hint and returned data.
+
 ## 3.3.2 - 2021-09-24
 - Add 'get users for role' endpoint.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.3.2"
+version = "3.3.3"
 description = "Python client for the Evergreen API"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1076,7 +1076,7 @@ class EvergreenApi(object):
         :param role: Role to fetch users for.
         """
         url = self._create_url(f"/roles/{role}/users")
-        return self._call_api(url, method="GET").json()
+        return self._call_api(url, method="GET").json()["users"]
 
     @classmethod
     def get_api(

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -43,6 +43,7 @@ from evergreen.task import Task
 from evergreen.task_annotations import TaskAnnotation
 from evergreen.task_reliability import TaskReliability
 from evergreen.tst import Tst
+from evergreen.users_for_role import UsersForRole
 from evergreen.util import evergreen_input_to_output, format_evergreen_date, iterate_by_time_window
 from evergreen.version import RecentVersions, Requester, Version
 
@@ -1069,14 +1070,14 @@ class EvergreenApi(object):
             payload["resource_id"] = resource_id
         self._call_api(url, method="DELETE", data=json.dumps(payload))
 
-    def get_users_for_role(self, role: str) -> List[str]:
+    def get_users_for_role(self, role: str) -> UsersForRole:
         """
         Get a list of users having an evergreen role.
 
         :param role: Role to fetch users for.
         """
         url = self._create_url(f"/roles/{role}/users")
-        return self._call_api(url, method="GET").json()["users"]
+        return UsersForRole(self._call_api(url, method="GET").json(), self)
 
     @classmethod
     def get_api(

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -459,7 +459,7 @@ def get_users_for_role(ctx, role):
     """Get users having an evergreen role."""
     api = ctx.obj["api"]
     users = api.get_users_for_role(role)
-    click.echo(users)
+    click.echo(users.users)
 
 
 def main():

--- a/src/evergreen/users_for_role.py
+++ b/src/evergreen/users_for_role.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+"""Representation of users having an evergreen role."""
+from typing import TYPE_CHECKING, Any, Dict
+
+from evergreen.base import _BaseEvergreenObject, evg_attrib
+
+if TYPE_CHECKING:
+    from evergreen.api import EvergreenApi
+
+
+class UsersForRole(_BaseEvergreenObject):
+    """Representation of a list of users having an evergreen role."""
+
+    users = evg_attrib("users")
+
+    def __init__(self, json: Dict[str, Any], api: "EvergreenApi") -> None:
+        """Create an instance of a UsersForRole object."""
+        super(UsersForRole, self).__init__(json, api)

--- a/tests/evergreen/cli/test_main.py
+++ b/tests/evergreen/cli/test_main.py
@@ -2,6 +2,7 @@ import json
 
 from evergreen import Manifest, TaskStats, TestStats, Version
 from evergreen.resource_type_permissions import RemovablePermission, ResourceTypePermissions
+from evergreen.users_for_role import UsersForRole
 
 try:
     from unittest.mock import MagicMock
@@ -309,7 +310,7 @@ def test_give_role_to_user(monkeypatch):
 def test_get_users_for_role(monkeypatch):
     evg_api_mock = _create_api_mock(monkeypatch)
     users = ["user1", "user2"]
-    evg_api_mock.get_users_for_role.return_value = {"users": users}
+    evg_api_mock.get_users_for_role.return_value = UsersForRole({"users": users}, None)
 
     cmd_list = ["get-users-for-role", "--role", "testrole"]
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -793,7 +793,7 @@ class TestRolesApi(object):
         mocked_api.session.request.assert_called_with(
             url=expected_url, params=None, timeout=None, data=None, method="GET"
         )
-        assert returned_response == {"users": users}
+        assert returned_response == users
 
 
 class TestCachedEvergreenApi(object):

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -793,7 +793,7 @@ class TestRolesApi(object):
         mocked_api.session.request.assert_called_with(
             url=expected_url, params=None, timeout=None, data=None, method="GET"
         )
-        assert returned_response == users
+        assert returned_response.users == users
 
 
 class TestCachedEvergreenApi(object):


### PR DESCRIPTION
…nd returned data.

* The server returns a dict of the form {"users": [users....]} so the type hint and returned data are inconsistent. 