### PR TITLE
DAG-1851 Add test count from task endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.6 - 2022-05-25
+
+- Add the number of tests that ran as part of the given task.
+
 ## 3.4.5 - 2022-05-11
 
 - Add `project_identifier` field to `Version` objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.4.5"
+version = "3.4.6"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -842,6 +842,16 @@ class EvergreenApi(object):
         param = {"test_name": test_file}
         return [Tst(test, self) for test in self._call_api(url, params=param).json()]
 
+    def num_of_tests_by_task(self, task_id: str) -> int:
+        """
+        Get the number of tests that ran as part of the given task.
+
+        :param task_id: Id of task to query for.
+        :return: Number of tests for the specified task.
+        """
+        url = self._create_url(f"/tasks/{task_id}/tests/count")
+        return int(self._call_api(url).text)
+
     def manifest_for_task(self, task_id: str) -> Manifest:
         """
         Get the manifest for the given task.

--- a/src/evergreen/task.py
+++ b/src/evergreen/task.py
@@ -339,6 +339,14 @@ class Task(_BaseEvergreenObject):
             execution=self.execution if execution is None else execution,
         )
 
+    def get_num_of_tests(self) -> int:
+        """
+        Get the number of tests that ran as part of this task.
+
+        :return: Number of tests for the task.
+        """
+        return self._api.num_of_tests_by_task(self.task_id)
+
     def get_execution_tasks(
         self, filter_fn: Optional[Callable[["Task"], bool]] = None
     ) -> Optional[List["Task"]]:

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -542,6 +542,13 @@ class TestTaskApi(object):
             url=expected_url, params=expected_params, timeout=None, data=None, method="GET"
         )
 
+    def test_num_of_tests_by_task(self, mocked_api):
+        mocked_api.num_of_tests_by_task("task_id")
+        expected_url = mocked_api._create_url("/tasks/task_id/tests/count")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
+
     def test_get_task_annotation(self, mocked_api):
         mocked_api.get_task_annotation("task_id", execution=5)
         expected_url = mocked_api._create_url("/tasks/task_id/annotations")

--- a/tests/evergreen/test_task.py
+++ b/tests/evergreen/test_task.py
@@ -228,6 +228,17 @@ class TestTask(object):
         assert "execution" in kwargs and kwargs["execution"] == expected
         assert tests == mock_api.tests_by_task.return_value
 
+    def test_get_num_of_tests(self, sample_task):
+        mock_api = MagicMock()
+        expected_num_of_tests = 2478
+        mock_api.num_of_tests_by_task.return_value = expected_num_of_tests
+        task = Task(sample_task, mock_api)
+
+        num_of_tests = task.get_num_of_tests()
+
+        mock_api.num_of_tests_by_task.assert_called_once()
+        assert num_of_tests == expected_num_of_tests
+
     @pytest.mark.parametrize(
         "status_string,status_score",
         [


### PR DESCRIPTION
Evergreen API returns just int value, e.g.:
https://evergreen.mongodb.com/rest/v2/tasks/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_required_jsCore_2330ce3962a1cbce03510d6cf8ccacc82e637c76_22_05_25_09_49_18/tests/count
```
2478
```