### PR TITLE
DAG-2439 Added APIs needed to create profiling enabled patches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.5.6 - 2023-04-13
+
+- Add new `patch_from_diff` command.
+- Add new `get_patch_diff` command.
+
 ## 3.5.5 - 2023-03-31
 
 - Add new `update_patch_status` command.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ $ evg-api --json list-hosts
 }
 ```
 
+The `patch_from_diff` API required the evergreen CLI to be installed. Add the following to the host's DOCKERFILE:
+
+```bash
+RUN wget https://evergreen.mongodb.com/clients/linux_amd64/evergreen
+RUN chmod +x evergreen
+ENV PATH="/project:$PATH"
+```
+
 ## Documentation
 
 You can find the documentation [here](https://evergreen-ci.github.io/evergreen.py/).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ evg-api --json list-hosts
 }
 ```
 
-The `patch_from_diff` API required the evergreen CLI to be installed. Add the following to the host's DOCKERFILE:
+The `patch_from_diff` API requires the Evergreen CLI to be installed. Add the following to the host's DOCKERFILE:
 
 ```bash
 RUN wget https://evergreen.mongodb.com/clients/linux_amd64/evergreen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.5.5"
+version = "3.5.6"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -401,9 +401,7 @@ class EvergreenApi(object):
                 attachment.dict(exclude_none=True, exclude_unset=True) for attachment in attachments
             ]
         self._call_api(
-            url,
-            data=json.dumps(data),
-            method="POST",
+            url, data=json.dumps(data), method="POST",
         )
 
     def alias_for_version(
@@ -1322,10 +1320,7 @@ class RetryingEvergreenApi(EvergreenApi):
 
     @retry(
         retry=retry_if_exception_type(  # type: ignore[no-untyped-call]
-            (
-                requests.exceptions.HTTPError,
-                requests.exceptions.ConnectionError,
-            )
+            (requests.exceptions.HTTPError, requests.exceptions.ConnectionError,)
         ),
         stop=stop_after_attempt(MAX_RETRIES),  # type: ignore[no-untyped-call]
         wait=wait_exponential(multiplier=1, min=START_WAIT_TIME_SEC, max=MAX_WAIT_TIME_SEC),  # type: ignore[no-untyped-call]

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -852,14 +852,12 @@ class EvergreenApi(object):
         :raises Exception: If a build URL is not produced we raise an exception with the output included.
         :return: _description_
         """
-        command = f"evergreen patch-file --diff-file {diff_file_path} --description '{description}' --param {params} --base {base} --tasks {task} --variants {variant} --project {project} -y"
+        command = f"evergreen patch-file --diff-file {diff_file_path} --description '{description}' --param {params} --base {base} --tasks {task} --variants {variant} --project {project} -y -f"
         process = subprocess.run(command, shell=True, check=True, capture_output=True)
-        print(process.stderr)
         match = re.search(EVERGREEN_URL_REGEX, str(process.stderr))
         if match is None:
             raise Exception(f"Unable to parse URL from command output: {str(process.stderr)}")
 
-        print(match.group(0))
         return PatchCreationDetails(url=match.group(0))
 
     def task_by_id(self, task_id: str, fetch_all_executions: Optional[bool] = None) -> Task:

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import
 
 import json
+import re
+import subprocess
 from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
@@ -30,7 +32,7 @@ from evergreen.config import (
 from evergreen.distro import Distro
 from evergreen.host import Host
 from evergreen.manifest import Manifest
-from evergreen.patch import Patch
+from evergreen.patch import Patch, PatchCreationDetails
 from evergreen.performance_results import PerformanceData
 from evergreen.project import Project
 from evergreen.resource_type_permissions import (
@@ -61,6 +63,8 @@ DEFAULT_LIMIT = 100
 MAX_RETRIES = 3
 START_WAIT_TIME_SEC = 2
 MAX_WAIT_TIME_SEC = 5
+
+EVERGREEN_URL_REGEX = "(https?)://evergreen..*?(?=\\\\n)"
 
 
 class EvergreenApi(object):
@@ -814,6 +818,49 @@ class EvergreenApi(object):
         """
         url = self._create_url(f"/patches/{patch_id}")
         return Patch(self._call_api(url, params).json(), self)  # type: ignore[arg-type]
+
+    def get_patch_diff(self, patch_id: str) -> str:
+        """
+        Get the diff for a given patch.
+
+        :param patch_id: The id of the patch to request the diff for.
+        :return: The diff of the patch represented as a JSON string.
+        """
+        url = self._create_url(f"/patches/{patch_id}/raw")
+        return json.dumps(self._call_api(url, method="GET").json())
+
+    def patch_from_diff(
+        self,
+        diff_file_path: str,
+        params: str,
+        base: str,
+        task: str,
+        project: str,
+        description: str,
+        variant: str,
+    ) -> PatchCreationDetails:
+        """
+        Start a patch build based on a diff.
+
+        :param diff_file_path: The path to the diff.
+        :param params: The params to pass to the build.
+        :param base: The build's base commit.
+        :param task: The task(s) to run.
+        :param project: The project to start the build for.
+        :param description: A description of the build.
+        :param variant: The variant(s) to build against.
+        :raises Exception: If a build URL is not produced we raise an exception with the output included.
+        :return: _description_
+        """
+        command = f"evergreen patch-file --diff-file {diff_file_path} --description '{description}' --param {params} --base {base} --tasks {task} --variants {variant} --project {project} -y"
+        process = subprocess.run(command, shell=True, check=True, capture_output=True)
+        print(process.stderr)
+        match = re.search(EVERGREEN_URL_REGEX, str(process.stderr))
+        if match is None:
+            raise Exception(f"Unable to parse URL from command output: {str(process.stderr)}")
+
+        print(match.group(0))
+        return PatchCreationDetails(url=match.group(0))
 
     def task_by_id(self, task_id: str, fetch_all_executions: Optional[bool] = None) -> Task:
         """

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -518,6 +518,32 @@ def all_user_permissions_for_resource(ctx, resource_id, resource_type):
     click.echo(user_permissions)
 
 
+@cli.command()
+@click.pass_context
+@click.option("--patch-id", required=True, help="Patch id to request diff for.")
+def patch_diff(ctx, patch_id):
+    """Get patch diff for a given patch."""
+    api = ctx.obj["api"]
+    diff = api.get_patch_diff(patch_id)
+    click.echo(diff)
+
+
+@cli.command()
+@click.pass_context
+@click.option("--diff-file", required=True, help="The path to the diff file.")
+@click.option("--description", required=True, help="The description of the build.")
+@click.option("--param", required=True, help="The params to pass to the build.")
+@click.option("--base", required=True, help="The base commit of the build.")
+@click.option("--project", required=True, help="The project of the build.")
+@click.option("--tasks", required=True, help="The tasks to execute.")
+@click.option("--variants", required=True, help="The variants to build against.")
+def patch_from_diff(ctx, diff_file, description, param, base, project, tasks, variants):
+    """Start a patch build based on the diff."""
+    api = ctx.obj["api"]
+    response = api.patch_from_diff(diff_file, param, base, tasks, project, description, variants)
+    click.echo(response)
+
+
 def main():
     """Create command line application."""
     return cli(obj={})

--- a/src/evergreen/cli/main.py
+++ b/src/evergreen/cli/main.py
@@ -537,10 +537,13 @@ def patch_diff(ctx, patch_id):
 @click.option("--project", required=True, help="The project of the build.")
 @click.option("--tasks", required=True, help="The tasks to execute.")
 @click.option("--variants", required=True, help="The variants to build against.")
-def patch_from_diff(ctx, diff_file, description, param, base, project, tasks, variants):
+@click.option("--author", required=False, default=None, help="Indicate the author of the patch.")
+def patch_from_diff(ctx, diff_file, description, param, base, project, tasks, variants, author):
     """Start a patch build based on the diff."""
     api = ctx.obj["api"]
-    response = api.patch_from_diff(diff_file, param, base, tasks, project, description, variants)
+    response = api.patch_from_diff(
+        diff_file, param, base, tasks, project, description, variants, author
+    )
     click.echo(response)
 
 

--- a/src/evergreen/patch.py
+++ b/src/evergreen/patch.py
@@ -1,7 +1,7 @@
 """Representation of an evergreen patch."""
 from __future__ import absolute_import
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Set
 
 from evergreen.base import _BaseEvergreenObject, evg_attrib, evg_datetime_attrib
 
@@ -99,6 +99,12 @@ class ModuleCodeChanges(_BaseEvergreenObject):
     def file_diffs(self) -> List[FileDiff]:
         """Retrieve a list of the file diffs for this patch."""
         return [FileDiff(diff, self._api) for diff in self.json["module_code_changes"]]
+
+
+class PatchCreationDetails(NamedTuple):
+    """Details of a patch creation."""
+
+    url: str
 
 
 class Patch(_BaseEvergreenObject):

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -543,6 +543,13 @@ class TestCreatePatchDiff:
         result = mocked_api.patch_from_diff(
             "path", "params", "base", "task", "project", "description", "variant"
         )
+
+        command = mock_run.call_args[0][0]
+
+        assert (
+            command
+            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f"
+        )
         assert (
             result.url
             == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -535,7 +535,7 @@ class TestPatchApi(object):
 
 class TestCreatePatchDiff:
     @patch("evergreen.api.subprocess.run",)
-    def test_patch_from_diff_valid(self, mock_run, mocked_api):
+    def test_patch_from_diff_valid_no_author(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
         mock_run.return_value = mock_stdout
@@ -549,6 +549,27 @@ class TestCreatePatchDiff:
         assert (
             command
             == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f"
+        )
+        assert (
+            result.url
+            == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
+        )
+
+    @patch("evergreen.api.subprocess.run",)
+    def test_patch_from_diff_valid_with_author(self, mock_run, mocked_api):
+        mock_stdout = MagicMock()
+        mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
+        mock_run.return_value = mock_stdout
+
+        result = mocked_api.patch_from_diff(
+            "path", "params", "base", "task", "project", "description", "variant", "author"
+        )
+
+        command = mock_run.call_args[0][0]
+
+        assert (
+            command
+            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --author author"
         )
         assert (
             result.url

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -525,6 +525,40 @@ class TestPatchApi(object):
             method="PATCH",
         )
 
+    def test_patch_diff_api(self, mocked_api):
+        mocked_api.get_patch_diff("patch_id")
+        expected_url = mocked_api._create_url("/patches/patch_id/raw")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
+
+
+class TestCreatePatchDiff:
+    @patch("evergreen.api.subprocess.run",)
+    def test_patch_from_diff_valid(self, mock_run, mocked_api):
+        mock_stdout = MagicMock()
+        mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
+        mock_run.return_value = mock_stdout
+
+        result = mocked_api.patch_from_diff(
+            "path", "params", "base", "task", "project", "description", "variant"
+        )
+        assert (
+            result.url
+            == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
+        )
+
+    @patch("evergreen.api.subprocess.run",)
+    def test_patch_from_diff_invalid(self, mock_run, mocked_api):
+        mock_stdout = MagicMock()
+        mock_stdout.stderr = b"no url here"
+        mock_run.return_value = mock_stdout
+
+        with pytest.raises(Exception):
+            mocked_api.patch_from_diff(
+                "path", "params", "base", "task", "project", "description", "variant"
+            )
+
 
 class TestTaskApi(object):
     def test_task_by_id(self, mocked_api):


### PR DESCRIPTION
These APIs are required for [DAG-2439](https://jira.mongodb.org/browse/DAG-2439?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true). You can see further discussion of these specific APIs in [EVG-19103](https://jira.mongodb.org/browse/EVG-19103).

This is the first of multiple PRs to enable this functionality. The subsequent PRs will be in signal-processing-service.

It's worth noting that the `patch-from-diff` command is unique in this repo because is not a REST API. It it's actually a CLI.

We could probably make the `patch-from-diff` API a little more flexible by not requiring all the params, but I don't think it's worth the time because it's really only being added for our specific usecase. 


Here are some example outputs from the CLI:

```bash
➜  evergreen.py git:(austin.hartschen/DAG-2439) ✗ poetry run evg-api patch-diff --patch-id 643452a33e8e8688ed564a3f          
{"patch_id": "643452a33e8e8688ed564a3f", "description": "master: SERVER-74888 Allow encrypted shell to always pass  through requests", "project_id": "mongodb-mongo-master", "project_identifier": "mongodb-mongo-master", "branch": "mongodb-mongo-master", "git_hash": "890b2ccfc81b4666db106529f179e66b1e918eac", "patch_number": 203, "author": "austin.hartschen", "version": "643452a33e8e8688ed564a3f", "status": "succeeded", "create_time": "2023-04-10T18:17:10.156Z", "start_time": "2023-04-10T18:40:31.468Z", "finish_time": "2023-04-10T18:47:13.329Z", "builds": ["commit-queue"], "tasks": ["version_gen_validation"], "downstream_tasks": null, "variants_tasks": [{"name": "commit-queue", "tasks": ["version_gen_validation"]}], "activated": true, "alias": "", "github_patch_data": {"pr_number": 0, "base_owner": "", "base_repo": "", "head_owner": "", "head_repo": "", "head_hash": "", "author": ""}, "module_code_changes": [{"branch_name": "mongodb-mongo-master", "html_link": "https://evergreen.mongodb.com/filediff/643452a33e8e8688ed564a3f?patch_number=0", "raw_link": "https://evergreen.mongodb.com/rawdiff/643452a33e8e8688ed564a3f?patch_number=0", "commit_messages": null, "file_diffs": [{"file_name": "etc/evergreen.yml", "additions": 1, "deletions": 0, "diff_link": "https://evergreen.mongodb.com/filediff/643452a33e8e8688ed564a3f?file_name=etc%2Fevergreen.yml&patch_number=0", "description": ""}, {"file_name": "etc/evergreen_yml_components/definitions.yml", "additions": 28, "deletions": 0, "diff_link": "https://evergreen.mongodb.com/filediff/643452a33e8e8688ed564a3f?file_name=etc%2Fevergreen_yml_components%2Fdefinitions.yml&patch_number=0", "description": ""}]}], "parameters": null, "project_storage_method": "", "patched_config": "", "can_enqueue_to_commit_queue": true, "child_patches": null, "requester": "patch_request", "merged_from": ""}
```

```bash
➜  evergreen.py git:(austin.hartschen/DAG-2439) ✗ poetry run evg-api patch-from-diff --diff-file empty.diff --description "Test enable profiling." --param "runtime_params_json='{\"v\": 0, \"enable_profiling\": true}'" --base 9fd56c17736f2e6557e5a91c6d607040ec191289 --project sys-perf --variants linux-standalone.2022-11 --tasks smoke_test
PatchCreationDetails(url='https://evergreen.mongodb.com/version/643884b07742aee732b1dc24?redirect_spruce_users=true')
```