### PR TITLE
DAG-2485 Add build_variant_display_name to Task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.8 - 2023-04-21
+
+- Add `build_variant_display_name` to `Task`
+
 ## 3.5.7 - 2023-04-21
 
 - Updated README

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.5.7"
+version = "3.5.8"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/task.py
+++ b/src/evergreen/task.py
@@ -107,6 +107,7 @@ class Task(_BaseEvergreenObject):
     activated_by = evg_attrib("activated_by")
     build_id = evg_attrib("build_id")
     build_variant = evg_attrib("build_variant")
+    build_variant_display_name = evg_attrib("build_variant_display_name")
     create_time = evg_datetime_attrib("create_time")
     depends_on = evg_attrib("depends_on")
     dispatch_time = evg_datetime_attrib("dispatch_time")

--- a/tests/evergreen/data/task.json
+++ b/tests/evergreen/data/task.json
@@ -16,7 +16,9 @@
   "build_id": "mongodb_mongo_master_linux_64_debug_patch_3a8290eef5c5934462b5cb84c9daded1b3073ad9_5c6469b6d6d80a06ba7b3aff_19_02_13_19_02_16",
   "distro_id": "rhel62-large",
   "build_variant": "linux-64-debug",
-  "depends_on": [ "mongodb_mongo_master_linux_64_debug_aggregation_patch_3a8290eef5c5934462b5cb84c9daded1b3073ad9_5c6469b6d6d80a06ba7b3aff_19_02_13_19_02_16"
+  "build_variant_display_name": "Linux 64 Debug",
+  "depends_on": [
+    "mongodb_mongo_master_linux_64_debug_aggregation_patch_3a8290eef5c5934462b5cb84c9daded1b3073ad9_5c6469b6d6d80a06ba7b3aff_19_02_13_19_02_16"
   ],
   "display_name": "aggregation_auth",
   "host_id": "sir-eh3i5x3j",
@@ -31,9 +33,7 @@
     "timed_out": false,
     "oom_tracker_info": {
       "detected": true,
-      "pids": [
-        19803
-      ]
+      "pids": [19803]
     }
   },
   "logs": {

--- a/tests/evergreen/test_task.py
+++ b/tests/evergreen/test_task.py
@@ -325,3 +325,8 @@ class TestTask(object):
         sample_task["status"] = status_string
         task = Task(sample_task, None)
         assert not task.is_completed()
+
+    def test_task_build_variant_display_name(self, sample_task):
+        task = Task(sample_task, None)
+
+        assert task.build_variant_display_name == "Linux 64 Debug"


### PR DESCRIPTION
Needed to add this field so we can add the attribute to the BFG collection, see [relevant code](https://github.com/10gen/build-baron-tools/blob/15debc0a0534da32d42102216ddffd4e70522439/src/bb/models/task_failure.py#L195) in BB Tools.