### PR TITLE
DAG-2538 Add metadata_links to TaskAnnotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.9 - 2023-05-02
+
+- Add `metadata_links` to `TaskAnnotation`
+
 ## 3.5.8 - 2023-04-21
 
 - Add `build_variant_display_name` to `Task`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.5.8"
+version = "3.5.9"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -18,7 +18,7 @@ from structlog.stdlib import LoggerFactory
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from evergreen.alias import VariantAlias
-from evergreen.api_requests import IssueLinkRequest, SlackAttachment
+from evergreen.api_requests import IssueLinkRequest, MetadataLinkRequest, SlackAttachment
 from evergreen.build import Build
 from evergreen.commitqueue import CommitQueue
 from evergreen.config import (
@@ -985,6 +985,7 @@ class EvergreenApi(object):
         issues: Optional[List[IssueLinkRequest]] = None,
         suspected_issues: Optional[List[IssueLinkRequest]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        metadata_links: Optional[List[MetadataLinkRequest]] = None,
     ) -> None:
         """
         Annotate the specified task.
@@ -995,6 +996,7 @@ class EvergreenApi(object):
         :param issues: Issues to attach to the annotation.
         :param suspected_issues: Suspected issues to add to the annotation.
         :param metadata: Extra metadata to add to the issue.
+        :param metadata_links: Metadata link to add to the annotation.
         """
         url = self._create_url(f"/tasks/{task_id}/annotation")
         request: Dict[str, Any] = {
@@ -1015,6 +1017,9 @@ class EvergreenApi(object):
 
         if metadata is not None:
             request["metadata"] = metadata
+
+        if metadata_links is not None:
+            request["metadata_links"] = [link._asdict() for link in metadata_links]
 
         self._call_api(url, method="PUT", data=json.dumps(request))
 

--- a/src/evergreen/api_requests.py
+++ b/src/evergreen/api_requests.py
@@ -19,6 +19,13 @@ class IssueLinkRequest(NamedTuple):
         return data
 
 
+class MetadataLinkRequest(NamedTuple):
+    """Metadata Link to add to a task annotation."""
+
+    url: str
+    text: str
+
+
 class SlackAttachmentField(BaseModel):
     """
     Slack fields that get displayed in a table-like format.

--- a/src/evergreen/task.py
+++ b/src/evergreen/task.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 
-from evergreen.api_requests import IssueLinkRequest
+from evergreen.api_requests import IssueLinkRequest, MetadataLinkRequest
 from evergreen.base import _BaseEvergreenObject, evg_attrib, evg_datetime_attrib
 from evergreen.manifest import Manifest
 from evergreen.task_annotations import TaskAnnotation
@@ -418,6 +418,7 @@ class Task(_BaseEvergreenObject):
         issues: Optional[List[IssueLinkRequest]] = None,
         suspected_issues: Optional[List[IssueLinkRequest]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        metadata_links: Optional[List[MetadataLinkRequest]] = None,
     ) -> None:
         """
         Annotate the specified task.
@@ -426,9 +427,16 @@ class Task(_BaseEvergreenObject):
         :param issues: Issues to attach to the annotation.
         :param suspected_issues: Suspected issues to add to the annotation.
         :param metadata: Extra metadata to add to the issue.
+        :param metadata_links: Metadata links to add to the annotation.
         """
         self._api.annotate_task(
-            self.task_id, self.execution, message, issues, suspected_issues, metadata
+            self.task_id,
+            self.execution,
+            message,
+            issues,
+            suspected_issues,
+            metadata,
+            metadata_links,
         )
 
     def __repr__(self) -> str:

--- a/src/evergreen/task_annotations.py
+++ b/src/evergreen/task_annotations.py
@@ -50,6 +50,22 @@ class Note(_BaseEvergreenObject):
         return Source(self.json["source"], self._api)
 
 
+class MetadataLink(_BaseEvergreenObject):
+    """Representation of a metadata link associated with a task annotation."""
+
+    url = evg_attrib("url")
+    text = evg_attrib("text")
+
+    def __init__(self, json: Dict[str, Any], api: "EvergreenApi") -> None:
+        """Create an instance of a task annotation metadata link."""
+        super().__init__(json, api)
+
+    @property
+    def source(self) -> Source:
+        """Get the source of this metadata link."""
+        return Source(self.json["source"], self._api)
+
+
 class TaskAnnotation(_BaseEvergreenObject):
     """Representation of a task annotation."""
 
@@ -79,3 +95,8 @@ class TaskAnnotation(_BaseEvergreenObject):
     def note(self) -> Note:
         """Get a note about this annotation."""
         return Note(self.json.get("note", {}), self._api)
+
+    @property
+    def metadata_links(self) -> List[MetadataLink]:
+        """Get metadata links for this annotation."""
+        return [MetadataLink(link, self._api) for link in self.json.get("metadata_links", [])]

--- a/tests/evergreen/data/task_annotations.json
+++ b/tests/evergreen/data/task_annotations.json
@@ -10,6 +10,17 @@
       "requester": "api"
     }
   },
+  "metadata_links": [
+    {
+      "url": "https://www.mongodb.com",
+      "text": "MongoDB",
+      "source": {
+        "author": "evergreen",
+        "time": "2020-12-02T22:02:41.329Z",
+        "requester": "api"
+      }
+    }
+  ],
   "issues": [
     {
       "url": "http://issues.com/ISSUE-1234",

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -11,7 +11,7 @@ import requests
 from requests.exceptions import HTTPError
 
 import evergreen.api as under_test
-from evergreen.api_requests import IssueLinkRequest, SlackAttachment
+from evergreen.api_requests import IssueLinkRequest, MetadataLinkRequest, SlackAttachment
 from evergreen.config import DEFAULT_API_SERVER, DEFAULT_NETWORK_TIMEOUT_SEC
 from evergreen.resource_type_permissions import PermissionableResourceType, RemovablePermission
 from evergreen.util import EVG_DATETIME_FORMAT, parse_evergreen_datetime
@@ -681,6 +681,7 @@ class TestTaskApi(object):
             "task_id",
             message="hello world",
             issues=[IssueLinkRequest(issue_key="key-1234", url="http://hello.world/key-1234")],
+            metadata_links=[MetadataLinkRequest(url="https://www.mongodb.com", text="mongodb")],
         )
         expected_url = mocked_api._create_url("/tasks/task_id/annotation")
         expected_params = None
@@ -689,6 +690,7 @@ class TestTaskApi(object):
                 "task_id": "task_id",
                 "note": {"message": "hello world"},
                 "issues": [{"issue_key": "key-1234", "url": "http://hello.world/key-1234"}],
+                "metadata_links": [{"url": "https://www.mongodb.com", "text": "mongodb"}],
             }
         )
         mocked_api.session.request.assert_called_with(

--- a/tests/evergreen/test_task_annotations.py
+++ b/tests/evergreen/test_task_annotations.py
@@ -13,3 +13,18 @@ class TestTaskAnnotation(object):
         assert len(task_annotation.suspected_issues) == len(
             sample_task_annotation["suspected_issues"]
         )
+
+        # Metadata Links assertions
+        assert len(task_annotation.metadata_links) == 1
+        assert (
+            task_annotation.metadata_links[0].url
+            == sample_task_annotation["metadata_links"][0]["url"]
+        )
+        assert (
+            task_annotation.metadata_links[0].text
+            == sample_task_annotation["metadata_links"][0]["text"]
+        )
+        assert (
+            task_annotation.metadata_links[0].source.json
+            == sample_task_annotation["metadata_links"][0]["source"]
+        )


### PR DESCRIPTION
See [DAG-2538](https://jira.mongodb.org/browse/DAG-2538).

I followed the [evergreen docs](https://docs.devprod.prod.corp.mongodb.com/evergreen/Use-the-API/REST-V2-Usage#resources) to model the field.

I ran the module locally and verified the outputs:

```
>>> task.annotate(metadata_links=[MetadataLinkRequest(url="https://evergreen.mongodb.com", text="evergreen")])
>>> for annotation in task.get_task_annotation(): print(annotation.__dict__)
{
    'json': {
        ... 
        'task_id': 'mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_all_feature_flags_required_display_sharding_multiversion_patch_5c0652aac3cb161cb8d0bcf0d80cdbb084a74d0c_637be734e3c331777894bc9b_22_11_21_21_01_52',
         ...,
         'metadata_links': [
             {'url': 'https://evergreen.mongodb.com', 'text': 'evergreen', 'source': {'author': 'evergreen', 'time': '2023-05-02T17:13:05.687Z', 'requester': 'api'}}
         ]},
         ...
     }
}
```

