### PR TITLE
DAG-2570 Make get_patch_diff return plain text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.3 - 2023-05-22
+
+- Change `get_patch_diff` to return plain text.
+
 ## 3.6.2 - 2023-05-18
 
 - Add logging in `Version` constructor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.2"
+version = "3.6.3"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -853,10 +853,10 @@ class EvergreenApi(object):
         Get the diff for a given patch.
 
         :param patch_id: The id of the patch to request the diff for.
-        :return: The diff of the patch represented as a JSON string.
+        :return: The diff of the patch represented as plain text.
         """
         url = self._create_url(f"/patches/{patch_id}/raw")
-        return json.dumps(self._call_api(url, method="GET").json())
+        return self._call_api(url, method="GET").text
 
     def patch_from_diff(
         self,


### PR DESCRIPTION
With the changes required for DAG-2570 we need this to be plain text now for use with the profiling build functionality. 