### PR TITLE
DAG-2619 Handled optionality of a task's manifest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.4 - 2023-05-22
+
+- Change `manifest_for_task` to return `Optional[Manifest]` in the case a manifest does not exist for the task.
+
 ## 3.6.3 - 2023-05-22
 
 - Change `get_patch_diff` to return plain text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.3"
+version = "3.6.4"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/task.py
+++ b/src/evergreen/task.py
@@ -396,7 +396,7 @@ class Task(_BaseEvergreenObject):
 
         return None
 
-    def get_manifest(self) -> Manifest:
+    def get_manifest(self) -> Optional[Manifest]:
         """Get the Manifest for this task."""
         return self._api.manifest_for_task(self.task_id)
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -612,6 +612,29 @@ class TestTaskApi(object):
             url=expected_url, params=None, timeout=None, data=None, method="GET"
         )
 
+    def test_manifest_for_task_does_not_exist(self, mocked_api):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"message": "no manifest found for version"}
+        mocked_api._session.request.side_effect = HTTPError(response=mock_response)
+        response = mocked_api.manifest_for_task("task_id")
+        expected_url = mocked_api._create_url("/tasks/task_id/manifest")
+        assert response is None
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params=None, timeout=None, data=None, method="GET"
+        )
+
+    def test_manifest_for_task_throws_exception(self, mocked_api):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"message": "unhandled exception"}
+        mocked_api._session.request.side_effect = HTTPError(response=mock_response)
+
+        with pytest.raises(HTTPError) as _:
+            mocked_api.manifest_for_task("task_id")
+            expected_url = mocked_api._create_url("/tasks/task_id/manifest")
+            mocked_api.session.request.assert_called_with(
+                url=expected_url, params=None, timeout=None, data=None, method="GET"
+            )
+
     def test_tests_by_task(self, mocked_api):
         mocked_api.tests_by_task("task_id")
         expected_url = mocked_api._create_url("/tasks/task_id/tests")


### PR DESCRIPTION
Based on the issue mentioned in [go/j/DAG-2619](http://go/j/DAG-2619) and [this slack thread](https://mongodb.slack.com/archives/C0V896UV8/p1684853932503299) it was established that a task does not always have an associated manifest. This change makes it clear that it is optional and we can then use this change to handle the case in SPS.

I also created [EVG-19971](https://jira.mongodb.org/browse/EVG-19971) for Evergreen to not throw a 500 in this case.