### PR TITLE
DAG-2434 Add 'num_total' attribute to TaskStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.6 - 2023-07-11
+
+- Add `num_total` to `TaskStats`.
+
 ## 3.6.5 - 2023-06-07
 
 - Added `revision_start` and `revision_end` to `versions_by_project`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.6.6 - 2023-07-11
+## 3.6.6 - 2023-07-12
 
 - Add `num_total` to `TaskStats`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.5"
+version = "3.6.6"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/stats.py
+++ b/src/evergreen/stats.py
@@ -41,6 +41,7 @@ class TaskStats(_BaseEvergreenObject):
     date = evg_date_attrib("date")
     num_pass = evg_attrib("num_success")
     num_fail = evg_attrib("num_failed")
+    num_total = evg_attrib("num_total")
     avg_duration_pass = evg_attrib("avg_duration_success")
 
     def __init__(self, json: Dict[str, Any], api: "EvergreenApi") -> None:

--- a/tests/evergreen/data/task_stats.json
+++ b/tests/evergreen/data/task_stats.json
@@ -5,5 +5,6 @@
     "date": "2019-02-23",
     "num_success": 4,
     "num_failed": 0,
+    "num_total": 4,
     "avg_duration_success": 82.01195722818375
   }

--- a/tests/evergreen/test_stats.py
+++ b/tests/evergreen/test_stats.py
@@ -16,6 +16,8 @@ class TestTaskStats(object):
     def test_get_attributes(self, sample_task_stats):
         task_stats = TaskStats(sample_task_stats, None)
         assert task_stats.task_name == sample_task_stats["task_name"]
+        assert task_stats.variant == sample_task_stats["variant"]
         assert task_stats.num_fail == sample_task_stats["num_failed"]
         assert task_stats.num_pass == sample_task_stats["num_success"]
+        assert task_stats.num_total == sample_task_stats["num_total"]
         assert task_stats.avg_duration_pass == sample_task_stats["avg_duration_success"]


### PR DESCRIPTION
According to [DAG-2434](https://jira.mongodb.org/browse/DAG-2434) we need TaskStats to have `variant` and `num_total` attributes. Attribute `variant` was already there, so added just `num_total`.