### PR TITLE
DAG-2700 Add support for tasks_by_project_and_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.7 - 2023-07-12
+
+- Add `tasks_by_project_and_name`.
+
 ## 3.6.5 - 2023-06-07
 
 - Added `revision_start` and `revision_end` to `versions_by_project`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.5"
+version = "3.6.7"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -692,6 +692,33 @@ class EvergreenApi(object):
         url = self._create_url(f"/projects/{project_id}/revisions/{commit_hash}/tasks")
         return [Task(json, self) for json in self._paginate(url, params)]  # type: ignore[arg-type]
 
+    def tasks_by_project_and_name(
+        self,
+        project_id: str,
+        task_name: str,
+        build_variant: Optional[str] = None,
+        num_versions: Optional[int] = None,
+        start_at: Optional[int] = None,
+    ) -> List[Task]:
+        """
+        Get all the tasks for a project by task name.
+
+        :param project_id: Id of project to query.
+        :param task_name: Name of task to query for.
+        :param build_variant: Only include tasks that have run on this build variant.
+        :param num_versions: The number of latest versions to be searched. Defaults to 20.
+        :param start_at: The version order number to start returning results after.
+        """
+        params: Dict[str, Any] = {}
+        if build_variant is not None:
+            params["build_variant"] = build_variant
+        if num_versions is not None:
+            params["num_versions"] = num_versions
+        if start_at is not None:
+            params["start_at"] = start_at
+        url = self._create_url(f"/projects/{project_id}/tasks/{task_name}")
+        return [Task(json, self) for json in self._paginate(url, params)]  # type: ignore[arg-type]
+
     def task_stats_by_project(
         self,
         project_id: str,

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -422,6 +422,26 @@ class TestProjectApi(object):
             url=expected_url, params={"status": ["status1"]}, timeout=None, data=None, method="GET"
         )
 
+    def test_tasks_by_project_and_name(self, mocked_api):
+        mocked_api.tasks_by_project_and_name("project_id", "task_name")
+        expected_url = mocked_api._create_url("/projects/project_id/tasks/task_name")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url, params={}, timeout=None, data=None, method="GET"
+        )
+
+    def test_tasks_by_project_and_name_with_params(self, mocked_api):
+        mocked_api.tasks_by_project_and_name(
+            "project_id", "task_name", build_variant="build_variant", num_versions=50, start_at=10
+        )
+        expected_url = mocked_api._create_url("/projects/project_id/tasks/task_name")
+        mocked_api.session.request.assert_called_with(
+            url=expected_url,
+            params={"build_variant": "build_variant", "num_versions": 50, "start_at": 10},
+            timeout=None,
+            data=None,
+            method="GET",
+        )
+
 
 class TestTaskStatsByProject(object):
     def test_with_multiple_tasks(self, mocked_api):


### PR DESCRIPTION
Wrapped the Evergreen API endpoint described [here](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage/#get-tasks-for-a-project)