### PR TITLE
DAG-2624 Update handling of manifests for new error codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.8 - 2023-07-24
+
+- Fix bug in `manifest_for_task` to return `Optional[Manifest]` in the case a manifest is not found.
+
 ## 3.6.7 - 2023-07-13
 
 - Add `tasks_by_project_and_name`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.7"
+version = "3.6.8"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -8,6 +8,7 @@ import subprocess
 from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
+from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from time import time
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Union, cast
@@ -1000,7 +1001,7 @@ class EvergreenApi(object):
         try:
             manifest = Manifest(self._call_api(url).json(), self)  # type: ignore[arg-type]
         except HTTPError as e:
-            if "no manifest found for version" not in e.response.json()["message"]:
+            if e.response.status_code != HTTPStatus.NOT_FOUND:
                 raise e
 
         return manifest

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -338,9 +338,7 @@ class TestProjectApi(object):
         }
 
         mocked_api.test_stats_by_project(
-            "project_id",
-            from_iso_format(after_date),
-            from_iso_format(before_date),
+            "project_id", from_iso_format(after_date), from_iso_format(before_date),
         )
 
         mocked_api.session.request.assert_called_with(
@@ -442,11 +440,7 @@ class TestProjectApi(object):
             {"build_variant": "build_variant", "num_versions": 50, "start_at": 10}
         )
         mocked_api.session.request.assert_called_with(
-            url=expected_url,
-            params=None,
-            timeout=None,
-            data=expected_data,
-            method="GET",
+            url=expected_url, params=None, timeout=None, data=expected_data, method="GET",
         )
 
 
@@ -562,9 +556,7 @@ class TestPatchApi(object):
 
 
 class TestCreatePatchDiff:
-    @patch(
-        "evergreen.api.subprocess.run",
-    )
+    @patch("evergreen.api.subprocess.run",)
     def test_patch_from_diff_valid_no_author(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
@@ -585,9 +577,7 @@ class TestCreatePatchDiff:
             == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
         )
 
-    @patch(
-        "evergreen.api.subprocess.run",
-    )
+    @patch("evergreen.api.subprocess.run",)
     def test_patch_from_diff_valid_with_author(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
@@ -608,9 +598,7 @@ class TestCreatePatchDiff:
             == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
         )
 
-    @patch(
-        "evergreen.api.subprocess.run",
-    )
+    @patch("evergreen.api.subprocess.run",)
     def test_patch_from_diff_invalid(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"no url here"
@@ -931,11 +919,7 @@ class TestUserPermissionsApi(object):
             "test.user", PermissionableResourceType.PROJECT, resources, permissions
         )
         mocked_api.session.request.assert_called_with(
-            url=expected_url,
-            params=None,
-            timeout=None,
-            data=expected_data,
-            method="POST",
+            url=expected_url, params=None, timeout=None, data=expected_data, method="POST",
         )
 
     def test_delete_user_permissions_all_resources(self, mocked_api):
@@ -943,11 +927,7 @@ class TestUserPermissionsApi(object):
         expected_data = json.dumps({"resource_type": RemovablePermission.PROJECT.value})
         mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT)
         mocked_api.session.request.assert_called_with(
-            url=expected_url,
-            params=None,
-            timeout=None,
-            data=expected_data,
-            method="DELETE",
+            url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
         )
 
     def test_delete_user_permissions_specific_resource(self, mocked_api):
@@ -957,11 +937,7 @@ class TestUserPermissionsApi(object):
         )
         mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT, "testresource")
         mocked_api.session.request.assert_called_with(
-            url=expected_url,
-            params=None,
-            timeout=None,
-            data=expected_data,
-            method="DELETE",
+            url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
         )
 
     def test_all_user_permissions_for_resource(self, mocked_api, mocked_api_response):
@@ -976,11 +952,7 @@ class TestUserPermissionsApi(object):
         )
         assert returned_permissions == permissions
         mocked_api.session.request.assert_called_with(
-            url=expected_url,
-            params=None,
-            timeout=None,
-            data=expected_data,
-            method="GET",
+            url=expected_url, params=None, timeout=None, data=expected_data, method="GET",
         )
 
 

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -3,6 +3,7 @@ import os
 import sys
 from copy import deepcopy
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from unittest.mock import MagicMock, patch
 
@@ -337,7 +338,9 @@ class TestProjectApi(object):
         }
 
         mocked_api.test_stats_by_project(
-            "project_id", from_iso_format(after_date), from_iso_format(before_date),
+            "project_id",
+            from_iso_format(after_date),
+            from_iso_format(before_date),
         )
 
         mocked_api.session.request.assert_called_with(
@@ -439,7 +442,11 @@ class TestProjectApi(object):
             {"build_variant": "build_variant", "num_versions": 50, "start_at": 10}
         )
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="GET",
+            url=expected_url,
+            params=None,
+            timeout=None,
+            data=expected_data,
+            method="GET",
         )
 
 
@@ -555,7 +562,9 @@ class TestPatchApi(object):
 
 
 class TestCreatePatchDiff:
-    @patch("evergreen.api.subprocess.run",)
+    @patch(
+        "evergreen.api.subprocess.run",
+    )
     def test_patch_from_diff_valid_no_author(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
@@ -576,7 +585,9 @@ class TestCreatePatchDiff:
             == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
         )
 
-    @patch("evergreen.api.subprocess.run",)
+    @patch(
+        "evergreen.api.subprocess.run",
+    )
     def test_patch_from_diff_valid_with_author(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
@@ -597,7 +608,9 @@ class TestCreatePatchDiff:
             == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
         )
 
-    @patch("evergreen.api.subprocess.run",)
+    @patch(
+        "evergreen.api.subprocess.run",
+    )
     def test_patch_from_diff_invalid(self, mock_run, mocked_api):
         mock_stdout = MagicMock()
         mock_stdout.stderr = b"no url here"
@@ -634,7 +647,7 @@ class TestTaskApi(object):
 
     def test_manifest_for_task_does_not_exist(self, mocked_api):
         mock_response = MagicMock()
-        mock_response.json.return_value = {"message": "no manifest found for version"}
+        mock_response.status_code = HTTPStatus.NOT_FOUND
         mocked_api._session.request.side_effect = HTTPError(response=mock_response)
         response = mocked_api.manifest_for_task("task_id")
         expected_url = mocked_api._create_url("/tasks/task_id/manifest")
@@ -918,7 +931,11 @@ class TestUserPermissionsApi(object):
             "test.user", PermissionableResourceType.PROJECT, resources, permissions
         )
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="POST",
+            url=expected_url,
+            params=None,
+            timeout=None,
+            data=expected_data,
+            method="POST",
         )
 
     def test_delete_user_permissions_all_resources(self, mocked_api):
@@ -926,7 +943,11 @@ class TestUserPermissionsApi(object):
         expected_data = json.dumps({"resource_type": RemovablePermission.PROJECT.value})
         mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT)
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
+            url=expected_url,
+            params=None,
+            timeout=None,
+            data=expected_data,
+            method="DELETE",
         )
 
     def test_delete_user_permissions_specific_resource(self, mocked_api):
@@ -936,7 +957,11 @@ class TestUserPermissionsApi(object):
         )
         mocked_api.delete_user_permissions("test.user", RemovablePermission.PROJECT, "testresource")
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="DELETE",
+            url=expected_url,
+            params=None,
+            timeout=None,
+            data=expected_data,
+            method="DELETE",
         )
 
     def test_all_user_permissions_for_resource(self, mocked_api, mocked_api_response):
@@ -951,7 +976,11 @@ class TestUserPermissionsApi(object):
         )
         assert returned_permissions == permissions
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=expected_data, method="GET",
+            url=expected_url,
+            params=None,
+            timeout=None,
+            data=expected_data,
+            method="GET",
         )
 
 


### PR DESCRIPTION
Manifests changed from using 500 for not found cases to using 404. Updated the unit tests and ran locally to verify new handling.


``` python
>>> r = api.manifest_for_task("wiredtiger_ubuntu2004_perf_tests_bench_wt2853_perf_test_row_patch_f0dd370a81c108edaaebc0bbce29eb8e20fad
10c_646c48ac3e8e8621411becde_23_05_23_05_02_54")
>>> print(r)
None
```