### PR TITLE
DAG-2824 Added patch_from_patch_id command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.6.10 - 2023-08-31
+
+- Add `patch_from_patch_id` command.
+- Use `reuse_compile_from` param on patch diffs.
+
 ## 3.6.9 - 2023-07-28
 
 - Add `stream` function for `Artifact`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.9"
+version = "3.6.10"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -563,14 +563,14 @@ class TestCreatePatchDiff:
         mock_run.return_value = mock_stdout
 
         result = mocked_api.patch_from_diff(
-            "path", "params", "base", "task", "project", "description", "variant"
+            "path", "params", "base", "task", "project", "description", "variant", "build_id"
         )
 
         command = mock_run.call_args[0][0]
 
         assert (
             command
-            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f"
+            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id"
         )
         assert (
             result.url
@@ -584,14 +584,22 @@ class TestCreatePatchDiff:
         mock_run.return_value = mock_stdout
 
         result = mocked_api.patch_from_diff(
-            "path", "params", "base", "task", "project", "description", "variant", "author"
+            "path",
+            "params",
+            "base",
+            "task",
+            "project",
+            "description",
+            "variant",
+            "build_id",
+            "author",
         )
 
         command = mock_run.call_args[0][0]
 
         assert (
             command
-            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --author author"
+            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id --author author"
         )
         assert (
             result.url
@@ -608,6 +616,27 @@ class TestCreatePatchDiff:
             mocked_api.patch_from_diff(
                 "path", "params", "base", "task", "project", "description", "variant"
             )
+
+    @patch("evergreen.api.subprocess.run",)
+    def test_patch_from_patch_id(self, mock_run, mocked_api):
+        mock_stdout = MagicMock()
+        mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
+        mock_run.return_value = mock_stdout
+
+        result = mocked_api.patch_from_patch_id(
+            "build_id", "params", "base", "task", "project", "description", "variant"
+        )
+
+        command = mock_run.call_args[0][0]
+
+        assert (
+            command
+            == "evergreen patch-file --diff-patchId build_id --description 'description' --param params --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id"
+        )
+        assert (
+            result.url
+            == "https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true"
+        )
 
 
 class TestTaskApi(object):


### PR DESCRIPTION
To be used in SPS for the "start profiling build" button to allow us to enable profiling of builds that contain module changes. 

I have imported this locally to that repo and confirmed it is working, so once this is released I can put up the PR for changes in SPS.