### PR TITLE
DAG-2860 Move logging configuration within constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.11 - 2023-09-07
+
+- Moved structlog configuration to within constructor.
+
 ## 3.6.10 - 2023-08-31
 
 - Add `patch_from_patch_id` command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.10"
+version = "3.6.11"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -57,7 +57,6 @@ except ImportError:
     from urllib.parse import urlparse  # type: ignore
 
 
-structlog.configure(logger_factory=LoggerFactory())
 LOGGER = structlog.getLogger(__name__)
 
 CACHE_SIZE = 5000
@@ -79,6 +78,7 @@ class EvergreenApi(object):
         timeout: Optional[int] = None,
         session: Optional[requests.Session] = None,
         log_on_error: bool = False,
+        configure_logging: bool = True 
     ) -> None:
         """
         Create a _BaseEvergreenApi object.
@@ -88,12 +88,17 @@ class EvergreenApi(object):
         :param timeout: Time (in sec) to wait before considering a call as failed.
         :param session: Session to use for requests.
         :param log_on_error: Flag to use for error logs.
+        :param configure_logging: Indication if the package should configure logging.
         """
         self._timeout = timeout
         self._api_server = api_server
         self._auth = auth
         self._session = session
         self._log_on_error = log_on_error
+
+        if configure_logging:
+            structlog.configure(logger_factory=LoggerFactory())
+            
 
     @contextmanager
     def with_session(self) -> Generator["EvergreenApi", None, None]:

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -78,7 +78,7 @@ class EvergreenApi(object):
         timeout: Optional[int] = None,
         session: Optional[requests.Session] = None,
         log_on_error: bool = False,
-        configure_logging: bool = True,
+        use_default_logger_factory: bool = True,
     ) -> None:
         """
         Create a _BaseEvergreenApi object.
@@ -88,7 +88,7 @@ class EvergreenApi(object):
         :param timeout: Time (in sec) to wait before considering a call as failed.
         :param session: Session to use for requests.
         :param log_on_error: Flag to use for error logs.
-        :param configure_logging: Indication if the package should configure logging.
+        :param use_default_logger_factory: Indicate if the module should configure the default logger factory.
         """
         self._timeout = timeout
         self._api_server = api_server
@@ -96,7 +96,7 @@ class EvergreenApi(object):
         self._session = session
         self._log_on_error = log_on_error
 
-        if configure_logging:
+        if use_default_logger_factory:
             structlog.configure(logger_factory=LoggerFactory())
 
     @contextmanager

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -78,7 +78,7 @@ class EvergreenApi(object):
         timeout: Optional[int] = None,
         session: Optional[requests.Session] = None,
         log_on_error: bool = False,
-        configure_logging: bool = True 
+        configure_logging: bool = True,
     ) -> None:
         """
         Create a _BaseEvergreenApi object.
@@ -98,7 +98,6 @@ class EvergreenApi(object):
 
         if configure_logging:
             structlog.configure(logger_factory=LoggerFactory())
-            
 
     @contextmanager
     def with_session(self) -> Generator["EvergreenApi", None, None]:


### PR DESCRIPTION
I opted to make the default for this True because we're using this in a lot of places already with the assumption that it's configured. 

Let me know if you feel differently. 