### PR TITLE
DAG-2390 solution made for disscussion to start

### DIFF
--- a/src/evergreen/patch.py
+++ b/src/evergreen/patch.py
@@ -1,7 +1,7 @@
 """Representation of an evergreen patch."""
 from __future__ import absolute_import
 
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Set, Union
 
 from evergreen.base import _BaseEvergreenObject, evg_attrib, evg_datetime_attrib
 
@@ -84,7 +84,7 @@ class ModuleCodeChanges(_BaseEvergreenObject):
     branch_name = evg_attrib("branch_name")
     html_link = evg_attrib("html_link")
     raw_link = evg_attrib("raw_link")
-    commit_messages = evg_attrib("commit_messages")
+    commit_messages: Union[property, List[Any]] = evg_attrib("commit_messages") or []
 
     def __init__(self, json: Dict[str, Any], api: "EvergreenApi") -> None:
         """


### PR DESCRIPTION
[DAG-2390](https://jira.mongodb.org/browse/DAG-2390) 

this issue comes from [this line in the validate_commit_message.py](https://github.com/10gen/mongo/blob/df0b06f9b337f258e8a53a1cd624b32873edf56b/buildscripts/validate_commit_message.py#L249C1-L250C1) file for mongo/buildscripts. i'm not sure if this change is exactly what we would want here, or if we would want to check for None before iterating in the `validate_commit_message.py` file instead. please let me know what you think and we can figure out the best solution possible!