### PR TITLE
DEVPROD-1575: added error for missing config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.6.17 - 2024-01-08
+- added error handling for missing config.
+
 ## 3.6.16 - 2023-11-14
 
 - Added support for sending emails.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.16"
+version = "3.6.17"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1447,9 +1447,7 @@ class EvergreenApi(object):
         if use_config_file:
             config = read_evergreen_config()
             if config is None:
-                raise FileNotFoundError(
-                    "The Evergreen config file cannot be found."
-                )
+                raise FileNotFoundError("The Evergreen config file cannot be found.")
         elif config_file is not None:
             config = read_evergreen_from_file(config_file)
 

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1446,6 +1446,10 @@ class EvergreenApi(object):
         config = None
         if use_config_file:
             config = read_evergreen_config()
+            if config is None:
+                raise FileNotFoundError(
+                    "The Evergreen config file cannot be found."
+                )
         elif config_file is not None:
             config = read_evergreen_from_file(config_file)
 

--- a/src/evergreen/config.py
+++ b/src/evergreen/config.py
@@ -38,7 +38,9 @@ def read_evergreen_config() -> Optional[Dict]:
     for filename in [filename for filename in CONFIG_FILE_LOCATIONS if os.path.isfile(filename)]:
         return read_evergreen_from_file(filename)
 
-    return None
+    raise FileNotFoundError(
+        f"The Evergreen config file cannot be found at the following locations:\n {CONFIG_FILE_LOCATIONS}"
+    )
 
 
 def get_auth_from_config(config: Dict) -> EvgAuth:

--- a/src/evergreen/config.py
+++ b/src/evergreen/config.py
@@ -40,7 +40,6 @@ def read_evergreen_config() -> Optional[Dict]:
     return None
 
 
-
 def get_auth_from_config(config: Dict) -> EvgAuth:
     """
     Get the evergreen authentication from the specified config dict.

--- a/src/evergreen/config.py
+++ b/src/evergreen/config.py
@@ -37,10 +37,8 @@ def read_evergreen_config() -> Optional[Dict]:
     """
     for filename in [filename for filename in CONFIG_FILE_LOCATIONS if os.path.isfile(filename)]:
         return read_evergreen_from_file(filename)
+    return None
 
-    raise FileNotFoundError(
-        f"The Evergreen config file cannot be found at the following locations:\n {CONFIG_FILE_LOCATIONS}"
-    )
 
 
 def get_auth_from_config(config: Dict) -> EvgAuth:


### PR DESCRIPTION
I've added a message that the evergreen file cannot be found when a user has set the flag to use it. The message also displays the locations of the configs