### PR TITLE
DEVPROD-3964 Allow parameters to be passed when creating patches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.6.19 - 2024-01-24
+
+- Added `parameters` field to `Version`.
+- Modified the `patch_from_diff` and `patch_from_patch_id` methods to include a parameters field to set parameters on the patch. 
+
 ## 3.6.18 - 2024-01-10
 
 - Added `id` field to `PatchCreationDetails`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.18"
+version = "3.6.19"
 description = "Python client for the Evergreen API"
 authors = [
     "Dev Prod DAG <dev-prod-dag@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -983,13 +983,12 @@ class EvergreenApi(object):
     def patch_from_diff(
         self,
         diff_file_path: str,
-        params: str,
+        params: dict[str, str],
         base: str,
         task: str,
         project: str,
         description: str,
         variant: str,
-        version_id: str,
         author: Optional[str] = None,
     ) -> PatchCreationDetails:
         """
@@ -1002,19 +1001,18 @@ class EvergreenApi(object):
         :param project: The project to start the build for.
         :param description: A description of the build.
         :param variant: The variant(s) to build against.
-        :param version_id: The version id this build is based on.
         :param author: The author to attribute for the build.
         :raises Exception: If a build URL is not produced we raise an exception with the output included.
         :return: The patch creation details.
         """
-        command = f"evergreen patch-file --diff-file {diff_file_path} --description '{description}' --param {params} --base {base} --tasks {task} --variants {variant} --project {project} -y -f --param reuse_compile_from={version_id}"
+        unpacked_params = " ".join([f"--param '{key}={value}'" for key, value in params.items()])
+        command = f"evergreen patch-file --diff-file {diff_file_path} --description '{description}' --base {base} --tasks {task} --variants {variant} --project {project} {unpacked_params} -y -f"
         return self._execute_patch_file_command(command, author)
 
     def patch_from_patch_id(
         self,
         patch_id: str,
-        params: str,
-        base: str,
+        params: dict[str, str],
         task: str,
         project: str,
         description: str,
@@ -1035,7 +1033,8 @@ class EvergreenApi(object):
         :raises Exception: If a build URL is not produced we raise an exception with the output included.
         :return: The patch creation details.
         """
-        command = f"evergreen patch-file --diff-patchId {patch_id} --description '{description}' --param {params} --tasks {task} --variants {variant} --project {project} -y -f --param reuse_compile_from={patch_id}"
+        unpacked_params = " ".join([f"--param '{key}={value}'" for key, value in params.items()])
+        command = f"evergreen patch-file --diff-patchId {patch_id} --description '{description}' --tasks {task} --variants {variant} --project {project} {unpacked_params} -y -f"
         return self._execute_patch_file_command(command, author)
 
     def task_by_id(

--- a/src/evergreen/version.py
+++ b/src/evergreen/version.py
@@ -103,6 +103,7 @@ class Version(_BaseEvergreenObject):
     ignored = evg_attrib("ignored")
     project_identifier = evg_attrib("project_identifier")
     aborted = evg_attrib("aborted")
+    parameters = evg_attrib("parameters")
 
     def __init__(self, json: Dict[str, Any], api: "EvergreenApi") -> None:
         """

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -573,15 +573,19 @@ class TestCreatePatchDiff:
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
         mock_run.return_value = mock_stdout
 
+        params = {
+            "runtime_params_json": '{"v": 0, "enable_profiling": true}',
+            "reuse_compile_from": "build_id",
+        }
         result = mocked_api.patch_from_diff(
-            "path", "params", "base", "task", "project", "description", "variant", "build_id"
+            "path", params, "base", "task", "project", "description", "variant"
         )
 
         command = mock_run.call_args[0][0]
 
         assert (
             command
-            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id"
+            == "evergreen patch-file --diff-file path --description 'description' --base base --tasks task --variants variant --project project --param 'runtime_params_json={\"v\": 0, \"enable_profiling\": true}' --param 'reuse_compile_from=build_id' -y -f"
         )
         assert (
             result.url
@@ -595,23 +599,19 @@ class TestCreatePatchDiff:
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
         mock_run.return_value = mock_stdout
 
+        params = {
+            "runtime_params_json": '{"v": 0, "enable_profiling": true}',
+            "reuse_compile_from": "build_id",
+        }
         result = mocked_api.patch_from_diff(
-            "path",
-            "params",
-            "base",
-            "task",
-            "project",
-            "description",
-            "variant",
-            "build_id",
-            "author",
+            "path", params, "base", "task", "project", "description", "variant", "author",
         )
 
         command = mock_run.call_args[0][0]
 
         assert (
             command
-            == "evergreen patch-file --diff-file path --description 'description' --param params --base base --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id --author author"
+            == "evergreen patch-file --diff-file path --description 'description' --base base --tasks task --variants variant --project project --param 'runtime_params_json={\"v\": 0, \"enable_profiling\": true}' --param 'reuse_compile_from=build_id' -y -f --author author"
         )
         assert (
             result.url
@@ -627,7 +627,7 @@ class TestCreatePatchDiff:
 
         with pytest.raises(Exception):
             mocked_api.patch_from_diff(
-                "path", "params", "base", "task", "project", "description", "variant"
+                "path", {}, "base", "task", "project", "description", "variant"
             )
 
     @patch("evergreen.api.subprocess.run",)
@@ -636,15 +636,19 @@ class TestCreatePatchDiff:
         mock_stdout.stderr = b"[evergreen] 2023/04/13 15:05:24 [p=info]: Patch successfully created.\n[evergreen] 2023/04/13 15:05:24 [p=info]: \n         ID : 64387ca457e85ac95a3da12f\n    Created : 2023-04-13 22:05:24.463 +0000 UTC\n    Description : Test enable profiling.\n      Build : https://evergreen.mongodb.com/patch/64387ca457e85ac95a3da12f?redirect_spruce_users=true\n     Status : created\n\n\n"
         mock_run.return_value = mock_stdout
 
+        params = {
+            "runtime_params_json": '{"v": 0, "enable_profiling": true}',
+            "reuse_compile_from": "build_id",
+        }
         result = mocked_api.patch_from_patch_id(
-            "build_id", "params", "base", "task", "project", "description", "variant"
+            "build_id", params, "task", "project", "description", "variant"
         )
 
         command = mock_run.call_args[0][0]
 
         assert (
             command
-            == "evergreen patch-file --diff-patchId build_id --description 'description' --param params --tasks task --variants variant --project project -y -f --param reuse_compile_from=build_id"
+            == "evergreen patch-file --diff-patchId build_id --description 'description' --tasks task --variants variant --project project --param 'runtime_params_json={\"v\": 0, \"enable_profiling\": true}' --param 'reuse_compile_from=build_id' -y -f"
         )
         assert (
             result.url


### PR DESCRIPTION
This change is to support more flexibility when passing params when creating copies of versions. I have already used this new pattern in Signal Processing Service where these methods are called and verified they support the flexibility we need for setting params. After this change is merged and released I will have a PR ready for SPS with the new version of evergreen.py.