### PR TITLE
DEVPROD-4784: Add caching support to tasks_by_build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.23 - 2024-03-12
+
+- Added cached support for the tasks_by_build method
+
 ## 3.6.22 - 2024-01-31
 
 - Updated README.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.22"
+version = "3.6.23"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1505,11 +1505,25 @@ class CachedEvergreenApi(EvergreenApi):
         """
         return super(CachedEvergreenApi, self).version_by_id(version_id)
 
+    @lru_cache(maxsize=CACHE_SIZE)
+    def tasks_by_build(self,
+                       build_id: str,
+                       fetch_all_executions: Optional[bool] = None
+                       ) -> List[Task]:
+        """
+        Get version by version id.
+
+        :param version_id: Id of version to query.
+        :return: Version queried for.
+        """
+        return super(CachedEvergreenApi, self).tasks_by_build(build_id=build_id, fetch_all_executions=fetch_all_executions)
+
     def clear_caches(self) -> None:
         """Clear the cache."""
         cached_functions = [
             self.build_by_id,
             self.version_by_id,
+            self.tasks_by_build,
         ]
         for fn in cached_functions:
             fn.cache_clear()  # type: ignore[attr-defined]

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1511,12 +1511,16 @@ class CachedEvergreenApi(EvergreenApi):
                        fetch_all_executions: Optional[bool] = None
                        ) -> List[Task]:
         """
-        Get version by version id.
+        Get tasks by build.
 
-        :param version_id: Id of version to query.
-        :return: Version queried for.
+        :param build_id: Id of build to query.
+        :param fetch_all_executions: should fetch all executions of the tasks
+        :return: List of the queried tasks.
         """
-        return super(CachedEvergreenApi, self).tasks_by_build(build_id=build_id, fetch_all_executions=fetch_all_executions)
+        return super(CachedEvergreenApi, self).tasks_by_build(
+            build_id=build_id,
+            fetch_all_executions=fetch_all_executions
+        )
 
     def clear_caches(self) -> None:
         """Clear the cache."""

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1506,10 +1506,9 @@ class CachedEvergreenApi(EvergreenApi):
         return super(CachedEvergreenApi, self).version_by_id(version_id)
 
     @lru_cache(maxsize=CACHE_SIZE)
-    def tasks_by_build(self,
-                       build_id: str,
-                       fetch_all_executions: Optional[bool] = None
-                       ) -> List[Task]:
+    def tasks_by_build(
+        self, build_id: str, fetch_all_executions: Optional[bool] = None
+    ) -> List[Task]:
         """
         Get tasks by build.
 
@@ -1518,8 +1517,7 @@ class CachedEvergreenApi(EvergreenApi):
         :return: List of the queried tasks.
         """
         return super(CachedEvergreenApi, self).tasks_by_build(
-            build_id=build_id,
-            fetch_all_executions=fetch_all_executions
+            build_id=build_id, fetch_all_executions=fetch_all_executions
         )
 
     def clear_caches(self) -> None:


### PR DESCRIPTION
https://jira.mongodb.org/browse/DEVPROD-4784

add caching support to the tasks_by_build method.