### PR TITLE
DEVPROD-5913: Fix file_diffs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.25 - 2024-04-15
+
+- Fix `file_diffs` endpoint.
+
 ## 3.6.24 - 2024-03-27
 
 - Switch to GitHub merge queue (no code changes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.24"
+version = "3.6.25"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/patch.py
+++ b/src/evergreen/patch.py
@@ -98,7 +98,7 @@ class ModuleCodeChanges(_BaseEvergreenObject):
     @property
     def file_diffs(self) -> List[FileDiff]:
         """Retrieve a list of the file diffs for this patch."""
-        return [FileDiff(diff, self._api) for diff in self.json["module_code_changes"]]
+        return [FileDiff(diff, self._api) for diff in self.json["file_diffs"]]
 
 
 class PatchCreationDetails(NamedTuple):


### PR DESCRIPTION
as discussed in: https://mongodb.slack.com/archives/C0V896UV8/p1713197760511919

this endpoint should return the file_diffs parameter, not module_code_changes