### PR TITLE
DEVPROD-7415 Avoid HTTP connection storm on EvergreenAPI python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.6.27 - 2024-05-22
+
+- `EvergreenApi` constructor now accepts an optional `urllib3.util.Retry` object that can be used to customize http request retry approach.
+- RetringEvergreenApi retry logic has been rewritten using `urllib3.util.Retry` instead of `Tenacity` library.
+- RetringEvergreenApi re-use same session across different requests.
+
 ## 3.6.26 - 2024-05-07
 
 - Add support for select tests endpoint

--- a/poetry.lock
+++ b/poetry.lock
@@ -1324,10 +1324,28 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.25.0"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "responses-0.25.0-py3-none-any.whl", hash = "sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a"},
+    {file = "responses-0.25.0.tar.gz", hash = "sha256:01ae6a02b4f34e39bffceb0fc6786b67a25eae919c6368d05eabc8d9576c2a66"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
+
+[[package]]
 name = "setuptools"
 version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1530,21 +1530,6 @@ tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=
 typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
-name = "tenacity"
-version = "8.2.3"
-description = "Retry code until it succeeds"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
-    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
-]
-
-[package.extras]
-doc = ["reno", "sphinx", "tornado (>=4.5)"]
-
-[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ coveralls = "^3.0.0"
 types-PyYAML = "^6.0.1"
 types-python-dateutil = "^2.8.2"
 types-requests = "^2.26.0"
+responses = "^0.25.0"
 
 [tool.pytest.ini_options]
 flake8-ignore = "W605 W503 W291 E203 E501 F821"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ python-dateutil = ">=2"
 PyYAML = ">=5"
 requests = ">=2"
 structlog = ">=19"
-tenacity = ">=5"
 pydantic = ">=1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.6.26"
+version = "3.6.27"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -104,6 +104,7 @@ class EvergreenApi(object):
         :param session: Session to use for requests.
         :param log_on_error: Flag to use for error logs.
         :param use_default_logger_factory: Indicate if the module should configure the default logger factory.
+        :param http_retry: Optional Retry object that can be used to customize http request retries.
         """
         self._timeout = timeout
         self._api_server = api_server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,12 +199,7 @@ def mocked_cached_api():
 @pytest.fixture()
 def mocked_retrying_api():
     """Return an Evergreen API with a mocked session."""
-    api = RetryingEvergreenApi()
-    api._session = MagicMock()
-    response_mock = MagicMock()
-    response_mock.status_code = 200
-    api._session.request.return_value = response_mock
-    return api
+    return RetryingEvergreenApi()
 
 
 @pytest.fixture()

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -6,13 +6,11 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from unittest import mock
-from unittest.mock import DEFAULT, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
 from requests.exceptions import HTTPError
-from urllib3.connectionpool import HTTPConnectionPool
 
 import evergreen.api as under_test
 from evergreen.api_requests import IssueLinkRequest, MetadataLinkRequest, SlackAttachment


### PR DESCRIPTION
In [DAG-527](https://jira.mongodb.org/browse/DAG-527) we made so that the EvergreenApi by default [establish a new HTTPS connection for every single Api call](https://github.com/evergreen-ci/evergreen.py/blob/9854bba6cb03c13f68e925e14225bda53c11ce23/src/evergreen/api.py#L112-L122). I realized that this is extremely inefficient , for instance the BuildBaron failure analyzer tool makes a lot of calls to the EVG Api during the setup phase that takes in average ~15 seconds in the setup phase. By re-using the same EVG Api session, the setup time goes down to 5 seconds.

I believe the changes in [DAG-527](https://jira.mongodb.org/browse/DAG-527) were motivated by the fact that in case of HTTP/network errors caused by an EVG application restart, the retries performed by the [RetringEvergreenApi](https://github.com/evergreen-ci/evergreen.py/blob/4ffdf60c8633d17492a64191181248b1393f6c56/src/evergreen/api.py#L566) were not effective because the session was not reset between retries attempts.

With this ticket, I'm proposing a different approach. The idea is to push down the retry logic to the session. This means that API requests failed do to HTTP / network errors will be retried, and the session will be reestablished as well. With this, we should be able to re-use the same session without worrying about the evg application restart.

The implementation is actually very simple and contained in the [offical 'requests' package documentation](https://requests.readthedocs.io/en/latest/user/advanced/#example-automatic-retries).

To maintain backward compatibility I've decided to only implement the sticky session in [RetringEvergreenApi](https://github.com/evergreen-ci/evergreen.py/blob/4ffdf60c8633d17492a64191181248b1393f6c56/src/evergreen/api.py#L566) but in the future we could also make it the default for EvergreenApi class.

With this new logic, we will have the following improvements:

-  Performance: improvements for RetringEvergreenApi class since it is re-using same session.
-  Code simplification: The RetringEvergreenApi is almost useless now, since it is simply passing a new constructor parameter to the base class.
- Modularity: Users of the library can now easily control the retry logic by passing a urllib3.util.Retry object to the EvergreenApi constructor.