### PR TITLE
DEVPROD-10470 - Add module parameter to get_patch_diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.9.1 - 2024-09-04
+- Add module parameter to get_patch_diff
+
 ## 3.9.0 - 2024-07-12
 
 - Add tags to builds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.9.0"
+version = "3.9.1"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -963,15 +963,17 @@ class EvergreenApi(object):
         url = self._create_url(f"/patches/{patch_id}")
         return Patch(self._call_api(url, params).json(), self)  # type: ignore[arg-type]
 
-    def get_patch_diff(self, patch_id: str) -> str:
+    def get_patch_diff(self, patch_id: str, module: str = "") -> str:
         """
         Get the diff for a given patch.
 
         :param patch_id: The id of the patch to request the diff for.
+        :param module: The module to get the diff for. Defaults to an empty string.
         :return: The diff of the patch represented as plain text.
         """
+        query_params = {"module": module} if module else None
         url = self._create_url(f"/patches/{patch_id}/raw")
-        return self._call_api(url, method="GET").text
+        return self._call_api(url=url, params=query_params, method="GET").text
 
     def _execute_patch_file_command(
         self, command: str, author: Optional[str] = None

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -560,10 +560,14 @@ class TestPatchApi(object):
         )
 
     def test_patch_diff_api(self, mocked_api):
-        mocked_api.get_patch_diff("patch_id")
+        mocked_api.get_patch_diff("patch_id", "test_module")
         expected_url = mocked_api._create_url("/patches/patch_id/raw")
         mocked_api.session.request.assert_called_with(
-            url=expected_url, params=None, timeout=None, data=None, method="GET"
+            url=expected_url,
+            params={"module": "test_module"},
+            timeout=None,
+            data=None,
+            method="GET",
         )
 
 


### PR DESCRIPTION
JIRA Ticket: https://jira.mongodb.org/browse/DEVPROD-10470

Description:
We update the get_patch_diff function to now pass in a optional "module" parameter to the `_call_api` function. We also update the unit tests to test for this functionality.
