### PR TITLE
DEVPROD-11185: Add includeRepo parameter to project API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.9.2 - 2024-09-10
+- Add includeRepo parameter to project API calls
+
 ## 3.9.1 - 2024-09-04
 - Add module parameter to get_patch_diff
 

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -420,7 +420,7 @@ class EvergreenApi(object):
         :param project_filter_fn: function to filter projects, should accept a project_id argument.
         :return: List of all projects in evergreen.
         """
-        url = self._create_url("/projects")
+        url = self._create_url("/projects?includeRepo=true")
         project_list = self._paginate(url)
         projects = [Project(project, self) for project in project_list]  # type: ignore[arg-type]
         if project_filter_fn is not None:
@@ -434,7 +434,7 @@ class EvergreenApi(object):
         :param project_id: Id of project to query.
         :return: Project specified.
         """
-        url = self._create_url(f"/projects/{project_id}")
+        url = self._create_url(f"/projects/{project_id}?includeRepo=true")
         return Project(self._paginate(url), self)  # type: ignore[arg-type]
 
     def recent_versions_by_project(


### PR DESCRIPTION
This fetches all of the project variables, including the ones set at the repo level. 

Testing: 
Tested API calls locally: 
https://evergreen.mongodb.com/rest/v2/projects/mms-v20240911?includeRepo=true
https://evergreen.mongodb.com/rest/v2/projects?includeRepo=true