### PR TITLE
DEVPROD-18380 fix evergreen route used for permissions for resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 3.11.3 - 2025-06-30
+- fix method `all_user_permissions_for_resource` call to endpoint `/permissions/users` instead of `/users/permissions`.
+
 ## 3.11.2 - 2025-06-23
 - Add compatibility for urllib3 < 2.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.11.2"
+version = "3.11.3"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1542,7 +1542,7 @@ class EvergreenApi(object):
         :param resource_type: Resource type of the resource.
         :return: A dict containing user to permissions mappings.
         """
-        url = self._create_url("/users/permissions")
+        url = self._create_url("/permissions/users")
         return self._call_api(
             url, data=json.dumps({"resource_id": resource_id, "resource_type": resource_type})
         ).json()

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -1029,7 +1029,7 @@ class TestUserPermissionsApi(object):
         )
 
     def test_all_user_permissions_for_resource(self, mocked_api, mocked_api_response):
-        expected_url = mocked_api._create_url("permissions/users")
+        expected_url = mocked_api._create_url("/permissions/users")
         expected_data = json.dumps(
             {"resource_id": "resource-1", "resource_type": PermissionableResourceType.PROJECT.value}
         )

--- a/tests/evergreen/test_api.py
+++ b/tests/evergreen/test_api.py
@@ -1029,7 +1029,7 @@ class TestUserPermissionsApi(object):
         )
 
     def test_all_user_permissions_for_resource(self, mocked_api, mocked_api_response):
-        expected_url = mocked_api._create_url("/users/permissions")
+        expected_url = mocked_api._create_url("permissions/users")
         expected_data = json.dumps(
             {"resource_id": "resource-1", "resource_type": PermissionableResourceType.PROJECT.value}
         )


### PR DESCRIPTION
This call should be using the /permissions/users [route](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage#tag/users/paths/~1permissions~1users/get) as opposed to the users/permissions [route](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage#tag/users/paths/~1users~1%7Buser_id%7D~1permissions/get) (I recognize we made this confusing haha but alas)

Lmk if there's something I should do here for testing or etc