### PR TITLE
Add compatibility for urllib3 versions < 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 3.11.2 - 2025-06-23
+- Add compatibility for urllib3 < 2.0.0
 
 ## 3.11.1 - 2025-04-21
 - Add additional logging for cloning patch

--- a/poetry.lock
+++ b/poetry.lock
@@ -1327,6 +1327,7 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "responses"
 version = "0.25.0"
 description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -1346,6 +1347,7 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 name = "setuptools"
 version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -1730,4 +1732,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ecd48ac0e64513a4839ac93903f56c8206401626018279ce996568be9bcca5cc"
+content-hash = "699a21bdcf1a19e241e6d7b41f43b13c5e92bfc5cc3bd691cec3c7c294b2a388"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.11.1"
+version = "3.11.2"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ PyYAML = ">=5"
 requests = ">=2"
 structlog = ">=19"
 pydantic = ">=1"
+urllib3 = ">2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ PyYAML = ">=5"
 requests = ">=2"
 structlog = ">=19"
 pydantic = ">=1"
-urllib3 = ">2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4"

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1721,7 +1721,6 @@ class RetryingEvergreenApi(EvergreenApi):
             raise_on_status=False,
             raise_on_redirect=False,
         )
-    DEFAULT_HTTP_RETRY.BACKOFF_MAX = DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
 
     def __init__(
         self,

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -12,11 +12,13 @@ from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from time import time
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Union, cast
+from distutils.version import StrictVersion
 
 import requests
 import structlog
 from requests.exceptions import HTTPError
 from structlog.stdlib import LoggerFactory
+import urllib3
 from urllib3.util import Retry
 
 from evergreen.alias import VariantAlias
@@ -1701,15 +1703,24 @@ class CachedEvergreenApi(EvergreenApi):
 
 class RetryingEvergreenApi(EvergreenApi):
     """An Evergreen Api that retries failed calls."""
-
-    DEFAULT_HTTP_RETRY = Retry(
+    if StrictVersion(urllib3.__version__) >= StrictVersion("2.0.0"):
+        DEFAULT_HTTP_RETRY = Retry(
+            total=DEFAULT_HTTP_RETRY_ATTEMPTS,
+            backoff_factor=DEFAULT_HTTP_RETRY_BACKOFF_FACTOR,
+            backoff_max=DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC,
+            status_forcelist=DEFAULT_HTTP_RETRY_CODES,
+            raise_on_status=False,
+            raise_on_redirect=False,
+        )
+    else:
+        DEFAULT_HTTP_RETRY = Retry(
         total=DEFAULT_HTTP_RETRY_ATTEMPTS,
         backoff_factor=DEFAULT_HTTP_RETRY_BACKOFF_FACTOR,
-        backoff_max=DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC,
         status_forcelist=DEFAULT_HTTP_RETRY_CODES,
         raise_on_status=False,
         raise_on_redirect=False,
     )
+    DEFAULT_HTTP_RETRY.DEFAULT_BACKOFF_MAX=DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
 
     def __init__(
         self,

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1721,7 +1721,7 @@ class RetryingEvergreenApi(EvergreenApi):
             raise_on_status=False,
             raise_on_redirect=False,
         )
-    DEFAULT_HTTP_RETRY.DEFAULT_BACKOFF_MAX = DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
+    DEFAULT_HTTP_RETRY.BACKOFF_MAX = DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
 
     def __init__(
         self,

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -7,18 +7,18 @@ import re
 import subprocess
 from contextlib import contextmanager
 from datetime import datetime
+from distutils.version import StrictVersion
 from functools import lru_cache
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from time import time
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Union, cast
-from distutils.version import StrictVersion
 
 import requests
 import structlog
+import urllib3
 from requests.exceptions import HTTPError
 from structlog.stdlib import LoggerFactory
-import urllib3
 from urllib3.util import Retry
 
 from evergreen.alias import VariantAlias
@@ -1703,6 +1703,7 @@ class CachedEvergreenApi(EvergreenApi):
 
 class RetryingEvergreenApi(EvergreenApi):
     """An Evergreen Api that retries failed calls."""
+
     if StrictVersion(urllib3.__version__) >= StrictVersion("2.0.0"):
         DEFAULT_HTTP_RETRY = Retry(
             total=DEFAULT_HTTP_RETRY_ATTEMPTS,
@@ -1714,13 +1715,13 @@ class RetryingEvergreenApi(EvergreenApi):
         )
     else:
         DEFAULT_HTTP_RETRY = Retry(
-        total=DEFAULT_HTTP_RETRY_ATTEMPTS,
-        backoff_factor=DEFAULT_HTTP_RETRY_BACKOFF_FACTOR,
-        status_forcelist=DEFAULT_HTTP_RETRY_CODES,
-        raise_on_status=False,
-        raise_on_redirect=False,
-    )
-    DEFAULT_HTTP_RETRY.DEFAULT_BACKOFF_MAX=DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
+            total=DEFAULT_HTTP_RETRY_ATTEMPTS,
+            backoff_factor=DEFAULT_HTTP_RETRY_BACKOFF_FACTOR,
+            status_forcelist=DEFAULT_HTTP_RETRY_CODES,
+            raise_on_status=False,
+            raise_on_redirect=False,
+        )
+    DEFAULT_HTTP_RETRY.DEFAULT_BACKOFF_MAX = DEFAULT_HTTP_RETRY_BACKOFF_MAX_SEC
 
     def __init__(
         self,


### PR DESCRIPTION
https://github.com/evergreen-ci/evergreen.py/commit/1e6da7d96c4b404cb4aed55044eaf02ef9ca8607 makes use of the `backoff_max` in urllib3's `Retry`, introduced in urllib3==2.0.0. This project does not specify a restriction on the version of urllib3. Further complicating, many downstream projects that use this package explicitly require urllib3 < 2.0.0. This adds compatibility for both.