### PR TITLE
DEVPROD-20931: Fix supported Python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.13.1 - 2025-08-15
+- Fix supported Python versions (only Python 3.9-3.13 supported)
+
 ## 3.13.0 - 2025-08-07
 - in a massive coincidence, python 3.13 support in version 3.13.0
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please include the following:
 
 ## Dependencies
 
-- Python 3.9 or later
+- Python 3.9-3.13
 
 ## Installation
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1270,5 +1270,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "907644d9c5dde404bcfcf82da122b9436834bd11c180dde2638b718e68e530dd"
+python-versions = ">=3.9,<3.14"
+content-hash = "4065de12db56f4ff86bc92a1c08484776b224a8759fdfe6e5df5f59a8a79fab6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.13.0"
+version = "3.13.1"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",
@@ -19,7 +19,7 @@ poetry-plugin-export = ">=1.8"
 evg-api = "evergreen.cli.main:main"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.9,<3.14"
 Click = "^8"
 python-dateutil = ">=2"
 PyYAML = ">=5"


### PR DESCRIPTION
- Only support Python 3.9-3.13, the same versions we have testing for in waterfall
- Installing evergreen API from an unsupported Python version will fail fast ([negative testing after setting required python<=3.13](https://parsley.mongodb.com/evergreen/evergreen.py_cp313_evg_api_install_patch_6795e6a8664ebd298fa9a647d5e2b214151b63b8_689f6301c3e9fc000727defa_25_08_15_16_40_36/0/task?bookmarks=0,154&selectedLineRange=L143))