### PR TITLE
DEVPROD-32896: Convert IssueLinkRequest and MetadataLinkRequest to Pydantic BaseModel

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -65,7 +65,7 @@ functions:
         command: "sh -c 'curl -sSL https://install.python-poetry.org | python3 -'"
         env:
           POETRY_HOME: ${workdir}/poetry
-          POETRY_VERSION: '2.1.4'
+          POETRY_VERSION: '2.2.1'
     - command: subprocess.exec
       params:
         command: ${workdir}/poetry/bin/poetry env use ${python_toolchain}/bin/python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
-## 3.16.0 - 2026-05-08
+## 3.17.0 - 2026-05-08
 - Convert IssueLinkRequest and MetadataLinkRequest from NamedTuple to Pydantic BaseModel.
 - Add an optional field model to class IssueLinkRequest
+
+## 3.16.0 - 2026-05-08
 - Add `GITHUB_MERGE_REQUEST` and `GIT_TAG_REQUEST` to `Requester` enum
 
 ## 3.15.0 - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.15.2 - 2026-05-07
+- Add optional `model` field to IssueLinkRequest.
+
 ## 3.15.1 - 2026-05-07
 - Convert IssueLinkRequest and MetadataLinkRequest from NamedTuple to Pydantic BaseModel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.15.1 - 2026-05-07
+- Convert IssueLinkRequest and MetadataLinkRequest from NamedTuple to Pydantic BaseModel.
+
 ## 3.15.0 - 2026-03-05
 - Add support for abort/restart/activate version endpoints.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
-## 3.15.2 - 2026-05-07
-- Add optional `model` field to IssueLinkRequest.
-
-## 3.15.1 - 2026-05-07
+## 3.16.0 - 2026-05-07
 - Convert IssueLinkRequest and MetadataLinkRequest from NamedTuple to Pydantic BaseModel.
+- Add an optional field model to class IssueLinkRequest
 
 ## 3.15.0 - 2026-03-05
 - Add support for abort/restart/activate version endpoints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.15.1"
+version = "3.15.2"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.15.2"
+version = "3.16.0"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.16.0"
+version = "3.17.0"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.15.0"
+version = "3.15.1"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -1374,7 +1374,7 @@ class EvergreenApi(object):
             request["metadata"] = metadata
 
         if metadata_links is not None:
-            request["metadata_links"] = [link._asdict() for link in metadata_links]
+            request["metadata_links"] = [link.model_dump() for link in metadata_links]
 
         self._call_api(url, method="PUT", data=json.dumps(request))
 

--- a/src/evergreen/api_requests.py
+++ b/src/evergreen/api_requests.py
@@ -11,6 +11,7 @@ class IssueLinkRequest(BaseModel):
     issue_key: str
     url: str
     confidence_score: Optional[float] = None
+    model: Optional[str] = None
 
     def as_dict(self) -> Dict[str, Any]:
         """Get a dictionary representation of the issue link."""

--- a/src/evergreen/api_requests.py
+++ b/src/evergreen/api_requests.py
@@ -1,11 +1,11 @@
 """Objects for making requests to the API."""
 
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
 
-class IssueLinkRequest(NamedTuple):
+class IssueLinkRequest(BaseModel):
     """Issue to add to a task annotation."""
 
     issue_key: str
@@ -14,13 +14,10 @@ class IssueLinkRequest(NamedTuple):
 
     def as_dict(self) -> Dict[str, Any]:
         """Get a dictionary representation of the issue link."""
-        data: Dict[str, Any] = {"issue_key": self.issue_key, "url": self.url}
-        if self.confidence_score is not None:
-            data["confidence_score"] = self.confidence_score
-        return data
+        return self.model_dump(exclude_none=True)
 
 
-class MetadataLinkRequest(NamedTuple):
+class MetadataLinkRequest(BaseModel):
     """Metadata Link to add to a task annotation."""
 
     url: str


### PR DESCRIPTION
## Summary

- Converts `IssueLinkRequest` and `MetadataLinkRequest` from `NamedTuple` to Pydantic `BaseModel`, making `api_requests.py` consistent throughout
- Adds an optional `model` (default to `None`) to `IssueLinkRequest`
- Updates `as_dict()` on `IssueLinkRequest` to use `model_dump(exclude_none=True)`, preserving the same behavior (omits `confidence_score`/`model` when `None`)
- Updates `MetadataLinkRequest` serialization in `api.py` from `._asdict()` to `.model_dump()`

## Test plan

- [x] Existing `test_annotate_task` and `test_annotate_task_with_zero_execution` tests pass without modification
- [x] `mypy` reports no issues on modified files