### PR TITLE
DEVPROD-36292 _raise_for_status should load content only for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 3.19.1 - 2026-06-29
-- Download response content only for errors
+- Download response content only for errors in _raise_for_status
 
 ## 3.19.0 - 2026-06-02
 - Revert changes made in version 3.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.19.1 - 2026-06-29
+- Download response content only for errors
+
 ## 3.19.0 - 2026-06-02
 - Revert changes made in version 3.17.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen.py"
-version = "3.19.0"
+version = "3.19.1"
 description = "Python client for the Evergreen API"
 authors = [
     "DevProd Services & Integrations Team <devprod-si-team@mongodb.com>",

--- a/src/evergreen/api.py
+++ b/src/evergreen/api.py
@@ -290,21 +290,22 @@ class EvergreenApi(object):
 
         :param response: response from evergreen api.
         """
-        try:
-            json_data = response.json()
-            if response.status_code >= 400 and "error" in json_data:
-                if self._log_on_error:
-                    LOGGER.error(
-                        "Error found in json",
-                        request_url=response.request.url,
-                        request_method=response.request.method,
-                        request_body=response.request.body,
-                        response_status_code=response.status_code,
-                        response_text=response.text,
-                    )
-                raise requests.exceptions.HTTPError(json_data["error"], response=response)
-        except JSONDecodeError:
-            pass
+        if response.status_code >= 400:
+            try:
+                json_data = response.json()
+                if "error" in json_data:
+                    if self._log_on_error:
+                        LOGGER.error(
+                            "Error found in json",
+                            request_url=response.request.url,
+                            request_method=response.request.method,
+                            request_body=response.request.body,
+                            response_status_code=response.status_code,
+                            response_text=response.text,
+                        )
+                    raise requests.exceptions.HTTPError(json_data["error"], response=response)
+            except JSONDecodeError:
+                pass
 
         response.raise_for_status()
 


### PR DESCRIPTION
_raise_for_status in evergreen.py calls response.json() regardless if there is an error or not. This causes an issue when we need to download a large log file because response.json() does not lazy download the that large file. response.json() should be called only when the response status is >= 400.